### PR TITLE
Bug 21 check the add tool modal its not showing any errors

### DIFF
--- a/src/app/components/app-shell.component.html
+++ b/src/app/components/app-shell.component.html
@@ -133,6 +133,7 @@
   [visible]="store.modalOpen()"
   [tool]="store.editingTool()"
   [saving]="store.saving()"
+  [saveError]="store.saveError()"
   (closed)="store.closeModal()"
   (submitted)="store.saveTool($event)"
 />

--- a/src/app/components/tool-form-modal.component.html
+++ b/src/app/components/tool-form-modal.component.html
@@ -14,11 +14,21 @@
   </header>
 
   <form class="modal-form" [formGroup]="form" #formElement (ngSubmit)="submit(formElement)">
+    @if (validationMessage() || saveError()) {
+      <div class="form-alert">
+        <strong>No se pudo guardar la herramienta.</strong>
+        <span>{{ saveError() || validationMessage() }}</span>
+      </div>
+    }
+
     <div class="grid two-columns">
 
       <label>
         <span>Nombre</span>
         <input formControlName="name" placeholder="Ej. Taladro electrico">
+        @if (fieldError('name'); as error) {
+          <small class="field-error">{{ error }}</small>
+        }
       </label>
 
       <label>
@@ -28,6 +38,9 @@
           <option value="En Uso">En Uso</option>
           <option value="En Mantenimiento">En Mantenimiento</option>
         </select>
+        @if (fieldError('state'); as error) {
+          <small class="field-error">{{ error }}</small>
+        }
       </label>
 
     </div>
@@ -37,16 +50,25 @@
       <label>
         <span>Marca</span>
         <input formControlName="brand" placeholder="Ej. Bosch, Stanley...">
+        @if (fieldError('brand'); as error) {
+          <small class="field-error">{{ error }}</small>
+        }
       </label>
 
       <label>
         <span>Modelo</span>
         <input formControlName="model" placeholder="Ej. GSB 13 RE...">
+        @if (fieldError('model'); as error) {
+          <small class="field-error">{{ error }}</small>
+        }
       </label>
 
       <label>
         <span>Tipo</span>
         <input formControlName="type" placeholder="Electrica, Manual, Corte...">
+        @if (fieldError('type'); as error) {
+          <small class="field-error">{{ error }}</small>
+        }
       </label>
 
     </div>
@@ -56,16 +78,25 @@
       <label>
         <span>Categoria</span>
         <input formControlName="category" placeholder="Perforacion, Obra...">
+        @if (fieldError('category'); as error) {
+          <small class="field-error">{{ error }}</small>
+        }
       </label>
 
       <label>
         <span>Material</span>
         <input formControlName="material" placeholder="Acero, ABS...">
+        @if (fieldError('material'); as error) {
+          <small class="field-error">{{ error }}</small>
+        }
       </label>
 
       <label>
         <span>Longitud (cm)</span>
         <input type="number" formControlName="long" min="1" step="0.1">
+        @if (fieldError('long'); as error) {
+          <small class="field-error">{{ error }}</small>
+        }
       </label>
 
     </div>
@@ -74,12 +105,18 @@
       <label>
         <span>URL de imagen</span>
         <input formControlName="urlSrc" placeholder="https://... o assets/tool-generic.svg">
+        @if (fieldError('urlSrc'); as error) {
+          <small class="field-error">{{ error }}</small>
+        }
       </label>
     </div>
 
     <label class="full-width">
       <span>Descripcion</span>
       <textarea rows="4" formControlName="description" placeholder="Descripcion operativa y estado actual"></textarea>
+      @if (fieldError('description'); as error) {
+        <small class="field-error">{{ error }}</small>
+      }
     </label>
 
     <div class="uploader">

--- a/src/app/components/tool-form-modal.component.scss
+++ b/src/app/components/tool-form-modal.component.scss
@@ -67,6 +67,24 @@
   gap: 1rem;
 }
 
+.form-alert {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.95rem 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(214, 95, 95, 0.22);
+  background: #fff4f4;
+  color: #9f2f2f;
+
+  strong {
+    font-size: 0.95rem;
+  }
+
+  span {
+    line-height: 1.45;
+  }
+}
+
 .grid {
   display: grid;
   gap: 1rem;
@@ -96,6 +114,12 @@ label,
     text-transform: uppercase;
     letter-spacing: 0.08em;
   }
+}
+
+.field-error {
+  color: #b43333;
+  font-size: 0.82rem;
+  font-weight: 700;
 }
 
 input,

--- a/src/app/components/tool-form-modal.component.ts
+++ b/src/app/components/tool-form-modal.component.ts
@@ -21,12 +21,14 @@ export class ToolFormModalComponent {
   readonly visible = input(false);
   readonly tool = input<Tool | null>(null);
   readonly saving = input(false);
+  readonly saveError = input<string | null>(null);
 
   readonly closed = output<void>();
   readonly submitted = output<ToolFormSubmission>();
 
   private readonly formBuilder = new FormBuilder();
   protected readonly selectedFileName = signal<string>('');
+  protected readonly validationMessage = signal<string | null>(null);
 
   protected readonly form = this.formBuilder.nonNullable.group({
     name: ['', [Validators.required]],
@@ -81,6 +83,7 @@ export class ToolFormModalComponent {
 
       this.selectedFileName.set('');
       this.removeCurrentImage.set(false);
+      this.validationMessage.set(null);
     });
   }
 
@@ -96,12 +99,15 @@ export class ToolFormModalComponent {
   }
 
   protected submit(formElement: HTMLFormElement): void {
+    this.validationMessage.set(null);
+
     if (this.form.getRawValue()['urlSrc'].trim() === '') {
       this.form.get('urlSrc')?.setValue('assets/tool-generic.svg');
     }
 
     if (this.form.invalid) {
       this.form.markAllAsTouched();
+      this.validationMessage.set(this.getFirstValidationError());
       return;
     }
 
@@ -115,5 +121,68 @@ export class ToolFormModalComponent {
       mode: this.tool() ? 'edit' : 'create'
     });
   }
-}
 
+  protected fieldError(name: keyof ReturnType<typeof this.form.getRawValue>): string | null {
+    const control = this.form.get(name);
+
+    if (!control || !control.invalid || !control.touched) {
+      return null;
+    }
+
+    if (control.errors?.['required']) {
+      return 'Este campo es obligatorio.';
+    }
+
+    if (control.errors?.['minlength']) {
+      return `Debe tener al menos ${control.errors['minlength'].requiredLength} caracteres.`;
+    }
+
+    if (control.errors?.['min']) {
+      return `Debe ser mayor o igual que ${control.errors['min'].min}.`;
+    }
+
+    return 'Valor no valido.';
+  }
+
+  private getFirstValidationError(): string {
+    const fields: Array<keyof ReturnType<typeof this.form.getRawValue>> = [
+      'name',
+      'type',
+      'category',
+      'description',
+      'urlSrc',
+      'state',
+      'material',
+      'long',
+      'brand',
+      'model'
+    ];
+
+    for (const field of fields) {
+      const error = this.fieldError(field);
+
+      if (error) {
+        return `${this.getFieldLabel(field)}: ${error}`;
+      }
+    }
+
+    return 'Revisa los campos obligatorios antes de continuar.';
+  }
+
+  private getFieldLabel(field: keyof ReturnType<typeof this.form.getRawValue>): string {
+    const labels: Record<keyof ReturnType<typeof this.form.getRawValue>, string> = {
+      name: 'Nombre',
+      type: 'Tipo',
+      category: 'Categoria',
+      description: 'Descripcion',
+      urlSrc: 'URL de imagen',
+      state: 'Estado',
+      material: 'Material',
+      long: 'Longitud',
+      brand: 'Marca',
+      model: 'Modelo'
+    };
+
+    return labels[field];
+  }
+}

--- a/src/app/services/tool-store.service.ts
+++ b/src/app/services/tool-store.service.ts
@@ -1,4 +1,5 @@
 import { computed, inject, Injectable, signal } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
 import { finalize } from 'rxjs';
 import { demoTools } from '../data/demo-tools';
 import { Tool, ToolFormSubmission, ToolListResponse } from '../models/tool.model';
@@ -28,6 +29,7 @@ export class ToolStoreService {
   readonly saving = signal(false);
   readonly modalOpen = signal(false);
   readonly editingTool = signal<Tool | null>(null);
+  readonly saveError = signal<string | null>(null);
   readonly useDemoData = signal(false);
   readonly bannerMessage = signal('Conectado a tu API de herramientas.');
 
@@ -157,21 +159,25 @@ export class ToolStoreService {
   }
 
   openCreateModal(): void {
+    this.saveError.set(null);
     this.editingTool.set(null);
     this.modalOpen.set(true);
   }
 
   openEditModal(tool: Tool): void {
+    this.saveError.set(null);
     this.editingTool.set(tool);
     this.modalOpen.set(true);
   }
 
   closeModal(): void {
+    this.saveError.set(null);
     this.modalOpen.set(false);
     this.editingTool.set(null);
   }
 
   saveTool(submission: ToolFormSubmission): void {
+    this.saveError.set(null);
     this.saving.set(true);
 
     if (this.useDemoData()) {
@@ -192,6 +198,7 @@ export class ToolStoreService {
             ? this.replaceTool(this.tools(), tool)
             : [tool, ...this.tools()];
 
+          this.saveError.set(null);
           this.tools.set(nextTools);
           this.bannerMessage.set('Herramienta sincronizada correctamente.');
           this.toastService.show({
@@ -210,11 +217,13 @@ export class ToolStoreService {
             this.uploadImage(tool.id, submission.file);
           }
         },
-        error: () => {
-          this.bannerMessage.set('No se pudo guardar en la API. Se mantiene la vista actual.');
+        error: (error: unknown) => {
+          const message = this.extractErrorMessage(error);
+          this.saveError.set(message);
+          this.bannerMessage.set(`No se pudo guardar: ${message}`);
           this.toastService.show({
             title: 'No se pudo guardar',
-            message: 'Revisa la conexion con la API e intentalo de nuevo.',
+            message,
             tone: 'error'
           });
         }
@@ -542,5 +551,51 @@ export class ToolStoreService {
       }))
       .sort((left, right) => right.total - left.total);
   }
-}
 
+  private extractErrorMessage(error: unknown): string {
+    if (error instanceof HttpErrorResponse) {
+      const payload = error.error as
+        | string
+        | { message?: string; error?: string; errors?: string[] | Record<string, string | string[]> }
+        | null;
+
+      if (typeof payload === 'string' && payload.trim()) {
+        return payload.trim();
+      }
+
+      if (payload && typeof payload === 'object') {
+        if (typeof payload.message === 'string' && payload.message.trim()) {
+          return payload.message.trim();
+        }
+
+        if (typeof payload.error === 'string' && payload.error.trim()) {
+          return payload.error.trim();
+        }
+
+        if (Array.isArray(payload.errors) && payload.errors.length > 0) {
+          return payload.errors.join(' ');
+        }
+
+        if (payload.errors && typeof payload.errors === 'object') {
+          const messages = Object.values(payload.errors)
+            .flatMap((value) => Array.isArray(value) ? value : [value])
+            .filter((value): value is string => typeof value === 'string' && value.trim().length > 0);
+
+          if (messages.length > 0) {
+            return messages.join(' ');
+          }
+        }
+      }
+
+      if (typeof error.message === 'string' && error.message.trim()) {
+        return error.message.trim();
+      }
+    }
+
+    if (error instanceof Error && error.message.trim()) {
+      return error.message.trim();
+    }
+
+    return 'Revisa los datos enviados e intentalo de nuevo.';
+  }
+}


### PR DESCRIPTION
It's been reviewed and improved. The Add Tool flow now clearly shows why it fails, whether the problem originates from the backend or form validations.

**Main changes**:
- In tool-store.service.ts, the actual HTTP error message is now extracted and saved in saveError, instead of just displaying generic text.
- In tool-form-modal.component.ts, I added handling of local validation errors and a summary of the first detected failure.
- In tool-form-modal.component.html, a visible alert now appears within the modal, along with messages below invalid fields.
- In tool-form-modal.component.scss, I added styling for these alerts.
- In app-shell.component.html, I connected the store error to the modal.

**Now, if it fails:**
- due to required or invalid data, the form tells you which field failed;
- due to a backend response, you'll see the actual reason within the modal and also in the toast message.