### PR TITLE
add new features

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -4,7 +4,9 @@ import { DashboardPageComponent } from './pages/dashboard/dashboard-page.compone
 import { InventoryPageComponent } from './pages/inventory/inventory-page.component';
 import { CategoriesPageComponent } from './pages/categories/categories-page.component';
 import { ReportsPageComponent } from './pages/reports/reports-page.component';
+import { RepairsPageComponent } from './pages/repairs/repairs-page.component';
 import { SettingsPageComponent } from './pages/settings/settings-page.component';
+import { TechniciansPageComponent } from './pages/technicians/technicians-page.component';
 
 export const appRoutes: Routes = [
   {
@@ -53,6 +55,26 @@ export const appRoutes: Routes = [
           eyebrow: 'Analitica',
           title: 'Reportes',
           description: 'Lectura rapida del estado general, uso y composicion del inventario.',
+          showCreateAction: false
+        }
+      },
+      {
+        path: 'arreglos',
+        component: RepairsPageComponent,
+        data: {
+          eyebrow: 'Mantenimiento',
+          title: 'Seguimiento de Arreglos',
+          description: 'Registro visual del historial de reparaciones y seguimiento por herramienta.',
+          showCreateAction: false
+        }
+      },
+      {
+        path: 'tecnicos',
+        component: TechniciansPageComponent,
+        data: {
+          eyebrow: 'Equipo',
+          title: 'Gestion de Tecnicos',
+          description: 'Alta, edicion y disponibilidad del personal que realiza los arreglos.',
           showCreateAction: false
         }
       },

--- a/src/app/components/app-shell.component.html
+++ b/src/app/components/app-shell.component.html
@@ -1,12 +1,7 @@
 <div class="dashboard-shell">
   @if (sidebarOpen()) {
-    <button
-      type="button"
-      class="sidebar-overlay"
-      [class.visible]="sidebarOpen()"
-      (click)="closeSidebar()"
-      aria-label="Cerrar menu lateral"
-    ></button>
+  <button type="button" class="sidebar-overlay" [class.visible]="sidebarOpen()" (click)="closeSidebar()"
+    aria-label="Cerrar menu lateral"></button>
   }
 
   <aside class="sidebar" [class.open]="sidebarOpen()">
@@ -34,6 +29,14 @@
       <a routerLink="/reportes" routerLinkActive="active" class="nav-item" (click)="closeSidebar()">
         <span class="nav-icon">◧</span>
         <span>Reportes</span>
+      </a>
+      <a routerLink="/arreglos" routerLinkActive="active" class="nav-item" (click)="closeSidebar()">
+        <span class="nav-icon">🛠</span>
+        <span>Arreglos</span>
+      </a>
+      <a routerLink="/tecnicos" routerLinkActive="active" class="nav-item" (click)="closeSidebar()">
+        <span class="nav-icon">👷</span>
+        <span>Tecnicos</span>
       </a>
       <a routerLink="/configuracion" routerLinkActive="active" class="nav-item" (click)="closeSidebar()">
         <span class="nav-icon">⚙</span>
@@ -75,34 +78,25 @@
   <main class="workspace">
     <header class="topbar">
       <div class="topbar-start">
-        <button
-          type="button"
-          class="menu-toggle"
-          [class.open]="sidebarOpen()"
-          [attr.data-tooltip]="sidebarOpen() ? null : 'Abrir menu'"
-          (click)="toggleSidebar()"
-          aria-label="Abrir o cerrar menu"
-        >
+        <button type="button" class="menu-toggle" [class.open]="sidebarOpen()"
+          [attr.data-tooltip]="sidebarOpen() ? null : 'Abrir menu'" (click)="toggleSidebar()"
+          aria-label="Abrir o cerrar menu">
           {{ sidebarOpen() ? '×' : '☰' }}
         </button>
 
         @if (showCreateAction()) {
-          <button type="button" class="create-button" (click)="store.openCreateModal()">
-            <span>＋</span>
-            Anadir Herramienta
-          </button>
+        <button type="button" class="create-button" (click)="store.openCreateModal()">
+          <span>＋</span>
+          Anadir Herramienta
+        </button>
         }
       </div>
 
       <div class="topbar-tools">
         <label class="search-box">
           <span>⌕</span>
-          <input
-            type="search"
-            placeholder="Buscar..."
-            [value]="store.searchTerm()"
-            (input)="store.updateSearch($any($event.target).value)"
-          >
+          <input type="search" placeholder="Buscar..." [value]="store.searchTerm()"
+            (input)="store.updateSearch($any($event.target).value)">
         </label>
 
         <button type="button" class="icon-button" aria-label="Notificaciones">🔔</button>
@@ -129,11 +123,5 @@
   </main>
 </div>
 
-<app-tool-form-modal
-  [visible]="store.modalOpen()"
-  [tool]="store.editingTool()"
-  [saving]="store.saving()"
-  [saveError]="store.saveError()"
-  (closed)="store.closeModal()"
-  (submitted)="store.saveTool($event)"
-/>
+<app-tool-form-modal [visible]="store.modalOpen()" [tool]="store.editingTool()" [saving]="store.saving()"
+  [saveError]="store.saveError()" (closed)="store.closeModal()" (submitted)="store.saveTool($event)" />

--- a/src/app/components/technician-form-modal.component.html
+++ b/src/app/components/technician-form-modal.component.html
@@ -1,0 +1,75 @@
+@if (visible()) {
+<div class="modal-backdrop" (click)="closed.emit()"></div>
+
+<section class="modal-panel" role="dialog" aria-modal="true" aria-label="Formulario de tecnico">
+  <header class="modal-header">
+    <div>
+      <p class="eyebrow">{{ technician() ? 'Edicion' : 'Nuevo tecnico' }}</p>
+      <h2>{{ technician() ? 'Actualizar tecnico' : 'Registrar tecnico' }}</h2>
+    </div>
+
+    <button type="button" class="close-button" (click)="closed.emit()" aria-label="Cerrar">
+      ×
+    </button>
+  </header>
+
+  <form class="modal-form" [formGroup]="form" (ngSubmit)="submit()">
+    @if (validationMessage() || saveError()) {
+      <div class="form-alert">
+        <strong>No se pudo guardar el tecnico.</strong>
+        <span>{{ saveError() || validationMessage() }}</span>
+      </div>
+    }
+
+    <div class="grid two-columns">
+      <label>
+        <span>Nombre</span>
+        <input formControlName="name" placeholder="Ej. Juan Perez">
+        @if (fieldError('name'); as error) {
+          <small class="field-error">{{ error }}</small>
+        }
+      </label>
+
+      <label>
+        <span>Especialidad</span>
+        <input formControlName="specialty" placeholder="Ej. Electrica, Soldadura...">
+        @if (fieldError('specialty'); as error) {
+          <small class="field-error">{{ error }}</small>
+        }
+      </label>
+    </div>
+
+    <div class="grid two-columns">
+      <label>
+        <span>Telefono</span>
+        <input formControlName="phone" placeholder="600 000 000">
+      </label>
+
+      <label>
+        <span>Correo</span>
+        <input formControlName="email" placeholder="tecnico@empresa.com">
+        @if (fieldError('email'); as error) {
+          <small class="field-error">{{ error }}</small>
+        }
+      </label>
+    </div>
+
+    <label class="full-width">
+      <span>Notas</span>
+      <textarea rows="4" formControlName="notes" placeholder="Turno, observaciones o certificaciones"></textarea>
+    </label>
+
+    <label class="status-toggle">
+      <input type="checkbox" formControlName="active">
+      <span>Activo para seleccionarlo en arreglos</span>
+    </label>
+
+    <div class="actions">
+      <button type="button" class="secondary" (click)="closed.emit()">Cancelar</button>
+      <button type="submit" class="primary" [disabled]="saving()">
+        {{ saving() ? 'Guardando...' : technician() ? 'Guardar cambios' : 'Crear tecnico' }}
+      </button>
+    </div>
+  </form>
+</section>
+}

--- a/src/app/components/technician-form-modal.component.scss
+++ b/src/app/components/technician-form-modal.component.scss
@@ -1,0 +1,191 @@
+:host {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  pointer-events: none;
+}
+
+.modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(28, 40, 73, 0.48);
+  backdrop-filter: blur(10px);
+  pointer-events: auto;
+}
+
+.modal-panel {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: min(680px, calc(100vw - 2rem));
+  max-height: calc(100vh - 3rem);
+  overflow: auto;
+  padding: 1.6rem;
+  border-radius: 26px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(247, 249, 255, 0.96));
+  box-shadow: 0 36px 90px rgba(16, 27, 56, 0.28);
+  transform: translate(-50%, -50%);
+  pointer-events: auto;
+}
+
+.modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.4rem;
+
+  .eyebrow {
+    margin: 0;
+    color: #4d77ef;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    font-size: 0.72rem;
+    font-weight: 800;
+  }
+
+  h2 {
+    margin: 0.3rem 0 0;
+    font-size: 1.8rem;
+    line-height: 1.1;
+    letter-spacing: -0.04em;
+  }
+}
+
+.close-button {
+  width: 2.6rem;
+  height: 2.6rem;
+  border-radius: 999px;
+  border: 1px solid rgba(83, 99, 137, 0.14);
+  background: #fff;
+  color: #354056;
+  font-size: 1.5rem;
+}
+
+.modal-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.form-alert {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.95rem 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(214, 95, 95, 0.22);
+  background: #fff4f4;
+  color: #9f2f2f;
+}
+
+.grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.two-columns {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+label,
+.full-width {
+  display: grid;
+  gap: 0.45rem;
+
+  span {
+    color: #556178;
+    font-size: 0.86rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+}
+
+.field-error {
+  color: #b43333;
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+input,
+textarea {
+  width: 100%;
+  min-height: 3rem;
+  padding: 0.8rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(92, 106, 144, 0.14);
+  background: rgba(248, 250, 255, 0.96);
+  color: #22304a;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+
+  &:focus {
+    outline: none;
+    border-color: rgba(70, 119, 246, 0.45);
+    box-shadow: 0 0 0 4px rgba(70, 119, 246, 0.12);
+  }
+}
+
+textarea {
+  resize: vertical;
+  min-height: 7rem;
+}
+
+.status-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 1.1rem;
+  border-radius: 16px;
+  background: #f4f7ff;
+
+  input {
+    width: 1rem;
+    min-height: auto;
+    padding: 0;
+  }
+
+  span {
+    text-transform: none;
+    letter-spacing: 0;
+    font-size: 0.96rem;
+  }
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.85rem;
+  margin-top: 0.5rem;
+}
+
+.primary,
+.secondary {
+  min-width: 176px;
+  min-height: 3rem;
+  padding: 0 1.2rem;
+  border-radius: 14px;
+  font-weight: 800;
+  border: none;
+}
+
+.primary {
+  background: linear-gradient(135deg, #4677f6, #2d60e9);
+  color: #fff;
+}
+
+.secondary {
+  background: #eef1fb;
+  color: #33405f;
+}
+
+@media (max-width: 900px) {
+  .two-columns,
+  .actions {
+    grid-template-columns: 1fr;
+    display: grid;
+  }
+
+  .primary,
+  .secondary {
+    width: 100%;
+  }
+}

--- a/src/app/components/technician-form-modal.component.ts
+++ b/src/app/components/technician-form-modal.component.ts
@@ -1,0 +1,136 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  effect,
+  input,
+  output,
+  signal
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { Technician, TechnicianFormSubmission } from '../models/repair.model';
+
+@Component({
+  selector: 'app-technician-form-modal',
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './technician-form-modal.component.html',
+  styleUrl: './technician-form-modal.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class TechnicianFormModalComponent {
+  readonly visible = input(false);
+  readonly technician = input<Technician | null>(null);
+  readonly saving = input(false);
+  readonly saveError = input<string | null>(null);
+
+  readonly closed = output<void>();
+  readonly submitted = output<TechnicianFormSubmission>();
+
+  private readonly formBuilder = new FormBuilder();
+  protected readonly validationMessage = signal<string | null>(null);
+
+  protected readonly form = this.formBuilder.nonNullable.group({
+    name: ['', [Validators.required]],
+    specialty: ['', [Validators.required]],
+    phone: [''],
+    email: ['', [Validators.email]],
+    notes: [''],
+    active: [true, [Validators.required]]
+  });
+
+  constructor() {
+    effect(() => {
+      if (!this.visible()) {
+        return;
+      }
+
+      const currentTechnician = this.technician();
+
+      if (currentTechnician) {
+        this.form.reset({
+          name: currentTechnician.name,
+          specialty: currentTechnician.specialty,
+          phone: currentTechnician.phone,
+          email: currentTechnician.email,
+          notes: currentTechnician.notes,
+          active: currentTechnician.active
+        });
+      } else {
+        this.form.reset({
+          name: '',
+          specialty: '',
+          phone: '',
+          email: '',
+          notes: '',
+          active: true
+        });
+      }
+
+      this.validationMessage.set(null);
+    });
+  }
+
+  protected submit(): void {
+    this.validationMessage.set(null);
+
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      this.validationMessage.set(this.getFirstValidationError());
+      return;
+    }
+
+    this.submitted.emit({
+      payload: this.form.getRawValue(),
+      mode: this.technician() ? 'edit' : 'create'
+    });
+  }
+
+  protected fieldError(name: keyof ReturnType<typeof this.form.getRawValue>): string | null {
+    const control = this.form.get(name);
+
+    if (!control || !control.invalid || !control.touched) {
+      return null;
+    }
+
+    if (control.errors?.['required']) {
+      return 'Este campo es obligatorio.';
+    }
+
+    if (control.errors?.['email']) {
+      return 'Introduce un correo valido.';
+    }
+
+    return 'Valor no valido.';
+  }
+
+  private getFirstValidationError(): string {
+    const fields: Array<keyof ReturnType<typeof this.form.getRawValue>> = [
+      'name',
+      'specialty',
+      'email'
+    ];
+
+    for (const field of fields) {
+      const error = this.fieldError(field);
+
+      if (error) {
+        return `${this.getFieldLabel(field)}: ${error}`;
+      }
+    }
+
+    return 'Revisa los campos obligatorios antes de continuar.';
+  }
+
+  private getFieldLabel(field: keyof ReturnType<typeof this.form.getRawValue>): string {
+    const labels: Record<keyof ReturnType<typeof this.form.getRawValue>, string> = {
+      name: 'Nombre',
+      specialty: 'Especialidad',
+      phone: 'Telefono',
+      email: 'Correo',
+      notes: 'Notas',
+      active: 'Estado'
+    };
+
+    return labels[field];
+  }
+}

--- a/src/app/components/tool-card.component.html
+++ b/src/app/components/tool-card.component.html
@@ -2,6 +2,10 @@
   <header class="card-header">
     <div>
       <h3>{{ tool().name }}</h3>
+      <div class="meta-strip">
+        <span class="meta-pill">Serie: {{ tool().serialNumber }}</span>
+        <span class="meta-pill meta-pill--soft">Ubicacion: {{ tool().location }}</span>
+      </div>
       <p [class.expanded]="expanded()" class="textlong">{{ tool().description }}</p>
       @if (tool().description.length > 100) {
       <span (click)="changeLongDescription()" class="toggle">

--- a/src/app/components/tool-card.component.scss
+++ b/src/app/components/tool-card.component.scss
@@ -35,6 +35,30 @@
   }
 }
 
+.meta-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: 0.55rem;
+}
+
+.meta-pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.8rem;
+  padding: 0.2rem 0.7rem;
+  border-radius: 999px;
+  background: #edf2ff;
+  color: #24459d;
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.meta-pill--soft {
+  background: #f1f5fb;
+  color: #596684;
+}
+
 .ghost-icon {
   display: inline-flex;
   gap: 0.22rem;

--- a/src/app/components/tool-card.component.ts
+++ b/src/app/components/tool-card.component.ts
@@ -36,7 +36,6 @@ export class ToolCardComponent {
       { label: 'Marca', value: tool.brand },
       { label: 'Modelo', value: tool.model },
       { label: 'Tipo', value: tool.type },
-      { label: 'Categoria', value: tool.category },
       { label: 'Material', value: tool.material },
       { label: 'Longitud', value: `${tool.long} cm` }
     ];

--- a/src/app/components/tool-form-modal.component.html
+++ b/src/app/components/tool-form-modal.component.html
@@ -15,10 +15,10 @@
 
   <form class="modal-form" [formGroup]="form" #formElement (ngSubmit)="submit(formElement)">
     @if (validationMessage() || saveError()) {
-      <div class="form-alert">
-        <strong>No se pudo guardar la herramienta.</strong>
-        <span>{{ saveError() || validationMessage() }}</span>
-      </div>
+    <div class="form-alert">
+      <strong>No se pudo guardar la herramienta.</strong>
+      <span>{{ saveError() || validationMessage() }}</span>
+    </div>
     }
 
     <div class="grid two-columns">
@@ -27,7 +27,7 @@
         <span>Nombre</span>
         <input formControlName="name" placeholder="Ej. Taladro electrico">
         @if (fieldError('name'); as error) {
-          <small class="field-error">{{ error }}</small>
+        <small class="field-error">{{ error }}</small>
         }
       </label>
 
@@ -39,7 +39,7 @@
           <option value="Mantenimiento">Mantenimiento</option>
         </select>
         @if (fieldError('state'); as error) {
-          <small class="field-error">{{ error }}</small>
+        <small class="field-error">{{ error }}</small>
         }
       </label>
 
@@ -51,7 +51,7 @@
         <span>Marca</span>
         <input formControlName="brand" placeholder="Ej. Bosch, Stanley...">
         @if (fieldError('brand'); as error) {
-          <small class="field-error">{{ error }}</small>
+        <small class="field-error">{{ error }}</small>
         }
       </label>
 
@@ -59,15 +59,26 @@
         <span>Modelo</span>
         <input formControlName="model" placeholder="Ej. GSB 13 RE...">
         @if (fieldError('model'); as error) {
-          <small class="field-error">{{ error }}</small>
+        <small class="field-error">{{ error }}</small>
         }
       </label>
 
       <label>
         <span>Tipo</span>
-        <input formControlName="type" placeholder="Electrica, Manual, Corte...">
+        <select formControlName="type" [disabled]="typeOptions().length === 0">
+          @if (typeOptions().length === 0) {
+          <option value="">Sin tipos configurados</option>
+          } @else {
+          @for (type of typeOptions(); track type) {
+          <option [value]="type">{{ type }}</option>
+          }
+          }
+        </select>
         @if (fieldError('type'); as error) {
-          <small class="field-error">{{ error }}</small>
+        <small class="field-error">{{ error }}</small>
+        }
+        @if (typeOptions().length === 0) {
+        <small class="field-error">Primero crea tipos desde Configuracion.</small>
         }
       </label>
 
@@ -79,7 +90,7 @@
         <span>Categoria</span>
         <input formControlName="category" placeholder="Perforacion, Obra...">
         @if (fieldError('category'); as error) {
-          <small class="field-error">{{ error }}</small>
+        <small class="field-error">{{ error }}</small>
         }
       </label>
 
@@ -87,7 +98,7 @@
         <span>Material</span>
         <input formControlName="material" placeholder="Acero, ABS...">
         @if (fieldError('material'); as error) {
-          <small class="field-error">{{ error }}</small>
+        <small class="field-error">{{ error }}</small>
         }
       </label>
 
@@ -95,7 +106,38 @@
         <span>Longitud (cm)</span>
         <input type="number" formControlName="long" min="1" step="0.1">
         @if (fieldError('long'); as error) {
-          <small class="field-error">{{ error }}</small>
+        <small class="field-error">{{ error }}</small>
+        }
+      </label>
+
+    </div>
+
+    <div class="grid two-columns">
+
+      <label>
+        <span>Numero de Serie</span>
+        <input formControlName="serialNumber" placeholder="Ej. SN-00045">
+        @if (fieldError('serialNumber'); as error) {
+        <small class="field-error">{{ error }}</small>
+        }
+      </label>
+
+      <label>
+        <span>Ubicacion</span>
+        <select formControlName="location" [disabled]="locationOptions().length === 0">
+          @if (locationOptions().length === 0) {
+          <option value="">Sin ubicaciones configuradas</option>
+          } @else {
+          @for (location of locationOptions(); track location) {
+          <option [value]="location">{{ location }}</option>
+          }
+          }
+        </select>
+        @if (fieldError('location'); as error) {
+        <small class="field-error">{{ error }}</small>
+        }
+        @if (locationOptions().length === 0) {
+        <small class="field-error">Primero crea ubicaciones desde Configuracion.</small>
         }
       </label>
 
@@ -106,7 +148,7 @@
         <span>URL de imagen</span>
         <input formControlName="urlSrc" placeholder="https://... o assets/tool-generic.svg">
         @if (fieldError('urlSrc'); as error) {
-          <small class="field-error">{{ error }}</small>
+        <small class="field-error">{{ error }}</small>
         }
       </label>
     </div>
@@ -115,7 +157,7 @@
       <span>Descripcion</span>
       <textarea rows="4" formControlName="description" placeholder="Descripcion operativa y estado actual"></textarea>
       @if (fieldError('description'); as error) {
-        <small class="field-error">{{ error }}</small>
+      <small class="field-error">{{ error }}</small>
       }
     </label>
 

--- a/src/app/components/tool-form-modal.component.ts
+++ b/src/app/components/tool-form-modal.component.ts
@@ -1,7 +1,9 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
   effect,
+  inject,
   input,
   output,
   signal
@@ -9,6 +11,8 @@ import {
 import { CommonModule } from '@angular/common';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Tool, ToolFormSubmission } from '../models/tool.model';
+import { LocationStoreService } from '../services/location-store.service';
+import { ToolTypeStoreService } from '../services/tool-type-store.service';
 
 @Component({
   selector: 'app-tool-form-modal',
@@ -26,9 +30,31 @@ export class ToolFormModalComponent {
   readonly closed = output<void>();
   readonly submitted = output<ToolFormSubmission>();
 
+  private readonly locationStore = inject(LocationStoreService);
+  private readonly toolTypeStore = inject(ToolTypeStoreService);
   private readonly formBuilder = new FormBuilder();
   protected readonly selectedFileName = signal<string>('');
   protected readonly validationMessage = signal<string | null>(null);
+  protected readonly typeOptions = computed(() => {
+    const baseOptions = this.toolTypeStore.typeNames();
+    const currentType = this.tool()?.type?.trim() ?? '';
+
+    if (currentType && !baseOptions.includes(currentType)) {
+      return [currentType, ...baseOptions];
+    }
+
+    return baseOptions;
+  });
+  protected readonly locationOptions = computed(() => {
+    const baseOptions = this.locationStore.locationNames();
+    const currentLocation = this.tool()?.location?.trim() ?? '';
+
+    if (currentLocation && !baseOptions.includes(currentLocation)) {
+      return [currentLocation, ...baseOptions];
+    }
+
+    return baseOptions;
+  });
 
   protected readonly form = this.formBuilder.nonNullable.group({
     name: ['', [Validators.required]],
@@ -40,12 +66,17 @@ export class ToolFormModalComponent {
     material: ['', [Validators.required]],
     long: [0, [Validators.required, Validators.min(1)]],
     brand: ['', [Validators.required]],
-    model: ['', [Validators.required]]
+    model: ['', [Validators.required]],
+    serialNumber: ['', [Validators.required]],
+    location: ['', [Validators.required]]
   });
 
   protected readonly removeCurrentImage = signal(false);
 
   constructor() {
+    this.locationStore.ensureLoaded();
+    this.toolTypeStore.ensureLoaded();
+
     effect(() => {
       const currentTool = this.tool();
 
@@ -64,7 +95,9 @@ export class ToolFormModalComponent {
           material: currentTool.material,
           long: currentTool.long,
           brand: currentTool.brand,
-          model: currentTool.model
+          model: currentTool.model,
+          serialNumber: currentTool.serialNumber,
+          location: currentTool.location
         });
       } else {
         this.form.reset({
@@ -77,13 +110,41 @@ export class ToolFormModalComponent {
           material: '',
           long: 20,
           brand: '',
-          model: ''
+          model: '',
+          serialNumber: '',
+          location: ''
         });
       }
 
       this.selectedFileName.set('');
       this.removeCurrentImage.set(false);
       this.validationMessage.set(null);
+    });
+
+    effect(() => {
+      if (!this.visible()) {
+        return;
+      }
+
+      const currentLocation = this.form.getRawValue().location;
+      const options = this.locationOptions();
+
+      if (!currentLocation && options.length > 0) {
+        this.form.patchValue({ location: options[0] }, { emitEvent: false });
+      }
+    });
+
+    effect(() => {
+      if (!this.visible()) {
+        return;
+      }
+
+      const currentType = this.form.getRawValue().type;
+      const options = this.typeOptions();
+
+      if (!currentType && options.length > 0) {
+        this.form.patchValue({ type: options[0] }, { emitEvent: false });
+      }
     });
   }
 
@@ -155,7 +216,9 @@ export class ToolFormModalComponent {
       'material',
       'long',
       'brand',
-      'model'
+      'model',
+      'serialNumber',
+      'location'
     ];
 
     for (const field of fields) {
@@ -180,7 +243,9 @@ export class ToolFormModalComponent {
       material: 'Material',
       long: 'Longitud',
       brand: 'Marca',
-      model: 'Modelo'
+      model: 'Modelo',
+      serialNumber: 'Numero de serie',
+      location: 'Ubicacion'
     };
 
     return labels[field];

--- a/src/app/data/demo-tools.ts
+++ b/src/app/data/demo-tools.ts
@@ -12,7 +12,9 @@ export const demoTools: Tool[] = [
     material: 'Acero y ABS',
     long: 31.5,
     brand: 'Bosch',
-    model: 'GSR 18V-28'
+    model: 'GSR 18V-28',
+    serialNumber: 'SN-TAL-00045',
+    location: 'Taller Mecanico'
   },
   {
     id: 'demo-sierra',
@@ -25,7 +27,9 @@ export const demoTools: Tool[] = [
     material: 'Aluminio',
     long: 28,
     brand: 'Makita',
-    model: 'LSX100'
+    model: 'LSX100',
+    serialNumber: 'SN-SIE-00018',
+    location: 'Area de Obra'
   },
   {
     id: 'demo-lijadora',
@@ -34,11 +38,13 @@ export const demoTools: Tool[] = [
     category: 'Mantenimiento',
     description: 'Requiere cambio de pad y revision del cable de alimentacion.',
     urlSrc: 'assets/tool-sander.svg',
-    state: 'Mantenimiento',
+    state: 'En Mantenimiento',
     material: 'Polimero industrial',
     long: 22,
     brand: 'DeWalt',
-    model: 'DWE6423'
+    model: 'DWE6423',
+    serialNumber: 'SN-LIJ-00027',
+    location: 'Zona de Diagnostico'
   },
   {
     id: 'demo-llave',
@@ -51,7 +57,9 @@ export const demoTools: Tool[] = [
     material: 'Acero forjado',
     long: 24,
     brand: 'Stanley',
-    model: 'STHT80640'
+    model: 'STHT80640',
+    serialNumber: 'SN-LLA-00011',
+    location: 'Almacen Central'
   },
   {
     id: 'demo-soldadora',
@@ -64,7 +72,8 @@ export const demoTools: Tool[] = [
     material: 'Acero pintado',
     long: 33,
     brand: 'Makita',
-    model: 'SPX100'
+    model: 'SPX100',
+    serialNumber: 'SN-SOL-00009',
+    location: 'Area de Soldadura'
   }
 ];
-

--- a/src/app/models/location.model.ts
+++ b/src/app/models/location.model.ts
@@ -1,0 +1,10 @@
+export interface ToolLocation {
+  id: string;
+  name: string;
+  description: string;
+}
+
+export interface LocationPayload {
+  name: string;
+  description: string;
+}

--- a/src/app/models/repair.model.ts
+++ b/src/app/models/repair.model.ts
@@ -1,0 +1,50 @@
+export interface Technician {
+  id: string;
+  name: string;
+  specialty: string;
+  phone: string;
+  email: string;
+  notes: string;
+  active: boolean;
+}
+
+export interface TechnicianPayload {
+  name: string;
+  specialty: string;
+  phone: string;
+  email: string;
+  notes: string;
+  active: boolean;
+}
+
+export interface TechnicianFormSubmission {
+  payload: TechnicianPayload;
+  mode: 'create' | 'edit';
+}
+
+export interface RepairRecord {
+  id: string;
+  toolId: string;
+  entryDate: string;
+  exitDate: string;
+  status: string;
+  priority: string;
+  issue: string;
+  description: string;
+  technicianId: string;
+  technicianName: string;
+  cost: number | null;
+  observations: string;
+}
+
+export interface RepairPayload {
+  entryDate: string;
+  exitDate: string;
+  status: string;
+  priority: string;
+  issue: string;
+  description: string;
+  technicianId: string;
+  cost: number | null;
+  observations: string;
+}

--- a/src/app/models/tool-type.model.ts
+++ b/src/app/models/tool-type.model.ts
@@ -1,0 +1,10 @@
+export interface ToolType {
+  id: string;
+  name: string;
+  description: string;
+}
+
+export interface ToolTypePayload {
+  name: string;
+  description: string;
+}

--- a/src/app/models/tool.model.ts
+++ b/src/app/models/tool.model.ts
@@ -10,6 +10,8 @@ export interface Tool {
   long: number;
   brand: string;
   model: string;
+  serialNumber: string;
+  location: string;
 }
 
 export interface ToolPayload {
@@ -23,6 +25,8 @@ export interface ToolPayload {
   long: number;
   brand: string;
   model: string;
+  serialNumber: string;
+  location: string;
 }
 
 export interface ToolFormSubmission {
@@ -43,4 +47,3 @@ export interface ToolListResponse {
     hasPreviousPage: boolean;
   };
 }
-

--- a/src/app/pages/inventory/inventory-page.component.html
+++ b/src/app/pages/inventory/inventory-page.component.html
@@ -1,103 +1,110 @@
 @if (store.loading()) {
-<section class="panel">Cargando inventario...</section>
+  <section class="panel">Cargando inventario...</section>
 } @else {
-<section class="inventory-grid">
-  <article class="inventory-table">
-    <header class="table-header">
-      <div>
-        <p class="eyebrow">Vista operativa</p>
-        <h3>Inventario completo</h3>
-      </div>
-      <span class="count">{{ rows().length }} items</span>
-    </header>
-
-    <div class="table">
-      <div class="table-row table-head">
-        <span>Herramienta</span>
-        <span>Categoria</span>
-        <span>Estado</span>
-        <span>Material</span>
-        <span>Longitud</span>
-        <span>Acciones</span>
-      </div>
-
-      @for (tool of rows(); track tool.id) {
-      <div class="table-row" [class.table-row--available]="getStateTone(tool.state) === 'available'"
-        [class.table-row--active]="getStateTone(tool.state) === 'active'"
-        [class.table-row--maintenance]="getStateTone(tool.state) === 'maintenance'">
-        <div class="tool-cell">
-          <img [src]="store.getImage(tool)" [alt]="tool.name">
-          <div>
-            <strong>{{ tool.name }}</strong>
-            <p>{{ tool.type }}</p>
-          </div>
+  <section class="inventory-grid">
+    <article class="inventory-table">
+      <header class="table-header">
+        <div>
+          <p class="eyebrow">Vista operativa</p>
+          <h3>Inventario completo</h3>
         </div>
-        <span>{{ tool.category }}</span>
-        <span class="status" [class.status--available]="getStateTone(tool.state) === 'available'"
-          [class.status--active]="getStateTone(tool.state) === 'active'"
-          [class.status--maintenance]="getStateTone(tool.state) === 'maintenance'">
-          {{ tool.state }}
-        </span>
-        <span>{{ tool.material }}</span>
-        <span>{{ tool.long }} cm</span>
-        <div class="row-actions">
-          <button type="button" (click)="store.openEditModal(tool)">Editar</button>
-          <button type="button" class="state-trigger"
-            [class.state-trigger--available]="getStateTone(tool.state) === 'available'"
-            [class.state-trigger--active]="getStateTone(tool.state) === 'active'"
-            [class.state-trigger--maintenance]="getStateTone(tool.state) === 'maintenance'"
-            (click)="toggleStateMenu(tool.id, $event)" [attr.aria-expanded]="openStateMenuId() === tool.id">
-            Estado: {{ tool.state }}
-          </button>
-          <div class="state-menu" (click)="$event.stopPropagation()">
-            @if (openStateMenuId() === tool.id) {
-            <div class="state-menu__panel">
-              @for (state of stateOptions; track state) {
-              <button type="button" class="state-option" [class.state-option--active]="isCurrentState(tool, state)"
-                [disabled]="isCurrentState(tool, state)" (click)="changeState(tool, state, $event)">
-                {{ state }}
-              </button>
-              }
+        <span class="count">{{ rows().length }} items</span>
+      </header>
+
+      <div class="table">
+        <div class="table-row table-head">
+          <span>Herramienta</span>
+          <span>Categoria</span>
+          <span>Estado</span>
+          <span>Material</span>
+          <span>Longitud</span>
+          <span>Acciones</span>
+        </div>
+
+        @for (tool of rows(); track tool.id) {
+          <div
+            class="table-row"
+            [class.table-row--available]="getStateTone(tool.state) === 'available'"
+            [class.table-row--active]="getStateTone(tool.state) === 'active'"
+            [class.table-row--maintenance]="getStateTone(tool.state) === 'maintenance'">
+            <div class="tool-cell">
+              <img [src]="store.getImage(tool)" [alt]="tool.name">
+              <div>
+                <strong>{{ tool.name }}</strong>
+                <p>{{ tool.type }}</p>
+              </div>
             </div>
-            }
+            <span>{{ tool.category }}</span>
+            <span class="status" [class.status--available]="getStateTone(tool.state) === 'available'" [class.status--active]="getStateTone(tool.state) === 'active'" [class.status--maintenance]="getStateTone(tool.state) === 'maintenance'">
+              {{ tool.state }}
+            </span>
+            <span>{{ tool.material }}</span>
+            <span>{{ tool.long }} cm</span>
+            <div class="row-actions">
+              <button type="button" (click)="store.openEditModal(tool)">Editar</button>
+              <div class="state-menu" (click)="$event.stopPropagation()">
+                <button
+                  type="button"
+                  class="state-trigger"
+                  [class.state-trigger--available]="getStateTone(tool.state) === 'available'"
+                  [class.state-trigger--active]="getStateTone(tool.state) === 'active'"
+                  [class.state-trigger--maintenance]="getStateTone(tool.state) === 'maintenance'"
+                  (click)="toggleStateMenu(tool.id, $event)"
+                  [attr.aria-expanded]="openStateMenuId() === tool.id">
+                  Estado: {{ tool.state }}
+                </button>
+
+                @if (openStateMenuId() === tool.id) {
+                  <div class="state-menu__panel">
+                    @for (state of stateOptions; track state) {
+                      <button
+                        type="button"
+                        class="state-option"
+                        [class.state-option--active]="isCurrentState(tool, state)"
+                        [disabled]="isCurrentState(tool, state)"
+                        (click)="changeState(tool, state, $event)">
+                        {{ state }}
+                      </button>
+                    }
+                  </div>
+                }
+              </div>
+              <button type="button" class="danger-action" (click)="store.deleteTool(tool)">Eliminar</button>
+            </div>
           </div>
-          <button type="button" class="danger-action" (click)="store.deleteTool(tool)">Eliminar</button>
-        </div>
-      </div>
-      } @empty {
-      <div class="table-row empty">No hay herramientas para mostrar.</div>
-      }
-    </div>
-  </article>
-
-  <aside class="inventory-side">
-    <article class="mini-panel">
-      <p class="eyebrow">Balance</p>
-      <h3>Estado del inventario</h3>
-      <div class="meter-group">
-        <div>
-          <span>Disponibles</span>
-          <strong>{{ store.stats().available }}</strong>
-        </div>
-        <div>
-          <span>En uso</span>
-          <strong>{{ store.stats().active }}</strong>
-        </div>
-        <div>
-          <span>Mantenimiento</span>
-          <strong>{{ store.stats().maintenance }}</strong>
-        </div>
+        } @empty {
+          <div class="table-row empty">No hay herramientas para mostrar.</div>
+        }
       </div>
     </article>
 
-    <article class="mini-panel">
-      <p class="eyebrow">Modo</p>
-      <h3>{{ store.useDemoData() ? 'Demo local' : 'API conectada' }}</h3>
-      <p class="muted">
-        {{ store.useDemoData() ? 'Estas navegando con datos de ejemplo.' : 'Las acciones se sincronizan con el backend.'
-        }}
-      </p>
-    </article>
-  </aside>
-</section>
+    <aside class="inventory-side">
+      <article class="mini-panel">
+        <p class="eyebrow">Balance</p>
+        <h3>Estado del inventario</h3>
+        <div class="meter-group">
+          <div>
+            <span>Disponibles</span>
+            <strong>{{ store.stats().available }}</strong>
+          </div>
+          <div>
+            <span>En uso</span>
+            <strong>{{ store.stats().active }}</strong>
+          </div>
+          <div>
+            <span>Mantenimiento</span>
+            <strong>{{ store.stats().maintenance }}</strong>
+          </div>
+        </div>
+      </article>
+
+      <article class="mini-panel">
+        <p class="eyebrow">Modo</p>
+        <h3>{{ store.useDemoData() ? 'Demo local' : 'API conectada' }}</h3>
+        <p class="muted">
+          {{ store.useDemoData() ? 'Estas navegando con datos de ejemplo.' : 'Las acciones se sincronizan con el backend.' }}
+        </p>
+      </article>
+    </aside>
+  </section>
 }

--- a/src/app/pages/repairs/repairs-page.component.html
+++ b/src/app/pages/repairs/repairs-page.component.html
@@ -1,0 +1,242 @@
+@if (!selectedTool()) {
+  <section class="empty-page">
+    <h3>Sin herramientas disponibles</h3>
+    <p>Necesitas herramientas cargadas en inventario para registrar arreglos.</p>
+  </section>
+} @else {
+  <section class="repairs-page">
+    <header class="repairs-header">
+      <div>
+        <p class="eyebrow">Seguimiento de Arreglos</p>
+        <h2>Seguimiento de Arreglo de Herramientas</h2>
+        <p class="intro">Registra y consulta el historial de reparaciones de cada herramienta.</p>
+      </div>
+
+      <label class="tool-selector">
+        <span>Herramienta</span>
+        <select [value]="selectedTool()!.id" (change)="selectTool($any($event.target).value)">
+          @for (tool of tools(); track tool.id) {
+            <option [value]="tool.id">{{ tool.name }}</option>
+          }
+        </select>
+      </label>
+    </header>
+
+    <article class="section-card">
+      <div class="section-title">
+        <span class="section-icon">🧰</span>
+        <h3>Informacion de la Herramienta</h3>
+      </div>
+
+      <div class="info-grid">
+        <label>
+          <span>Codigo / ID</span>
+          <input [value]="selectedMeta()?.code ?? selectedTool()!.id" readonly>
+        </label>
+
+        <label>
+          <span>Nombre de la Herramienta</span>
+          <input [value]="selectedTool()!.name" readonly>
+        </label>
+
+        <label>
+          <span>Marca</span>
+          <input [value]="selectedTool()!.brand" readonly>
+        </label>
+
+        <label>
+          <span>Modelo</span>
+          <input [value]="selectedTool()!.model" readonly>
+        </label>
+
+        <label>
+          <span>Numero de Serie</span>
+          <input [value]="selectedTool()!.serialNumber" readonly>
+        </label>
+
+        <label>
+          <span>Ubicacion Actual</span>
+          <select
+            [value]="selectedTool()!.location"
+            [disabled]="locationOptions().length === 0 || updatingLocation()"
+            (change)="updateLocation($any($event.target).value)">
+            @if (locationOptions().length === 0) {
+              <option [value]="selectedTool()!.location">{{ selectedTool()!.location || 'Sin ubicaciones configuradas' }}</option>
+            } @else {
+              @for (location of locationOptions(); track location) {
+                <option [value]="location">{{ location }}</option>
+              }
+            }
+          </select>
+          @if (locationOptions().length === 0) {
+            <small class="field-error">No hay ubicaciones configuradas en la aplicacion.</small>
+          }
+        </label>
+
+        <div class="status-field">
+          <span>Estado Actual</span>
+          <div
+            class="state-pill"
+            [class.state-pill--available]="getToolStateTone(selectedTool()!.state) === 'available'"
+            [class.state-pill--active]="getToolStateTone(selectedTool()!.state) === 'active'"
+            [class.state-pill--maintenance]="getToolStateTone(selectedTool()!.state) === 'maintenance'">
+            {{ selectedTool()!.state }}
+          </div>
+        </div>
+
+        <div class="image-field">
+          <span>Imagen (opcional)</span>
+          <div class="image-card">
+            <img [src]="store.getImage(selectedTool()!)" [alt]="selectedTool()!.name">
+            <button type="button" class="image-edit" (click)="openSelectedToolEditor()">✎</button>
+          </div>
+        </div>
+      </div>
+    </article>
+
+    <article class="section-card">
+      <div class="section-title">
+        <span class="section-icon">🛠</span>
+        <h3>Registrar Nuevo Arreglo</h3>
+      </div>
+
+      <form class="repair-form" [formGroup]="repairForm" (ngSubmit)="saveRepair()">
+        <div class="form-grid four-columns">
+          <label>
+            <span>Fecha de Entrada</span>
+            <input type="date" formControlName="entryDate">
+            @if (fieldError('entryDate'); as error) {
+              <small class="field-error">{{ error }}</small>
+            }
+          </label>
+
+          <label>
+            <span>Fecha de Salida</span>
+            <input type="date" formControlName="exitDate">
+            @if (fieldError('exitDate'); as error) {
+              <small class="field-error">{{ error }}</small>
+            }
+          </label>
+
+          <label>
+            <span>Estado</span>
+            <select formControlName="status">
+              <option value="Reparado">Reparado</option>
+              <option value="En revision">En revision</option>
+              <option value="Pendiente">Pendiente</option>
+            </select>
+          </label>
+
+          <label>
+            <span>Prioridad</span>
+            <select formControlName="priority">
+              <option value="Normal">Normal</option>
+              <option value="Alta">Alta</option>
+              <option value="Critica">Critica</option>
+            </select>
+          </label>
+        </div>
+
+        <div class="form-grid two-columns">
+          <label>
+            <span>Motivo / Falla Reportada</span>
+            <textarea rows="4" formControlName="issue"></textarea>
+            @if (fieldError('issue'); as error) {
+              <small class="field-error">{{ error }}</small>
+            }
+          </label>
+
+          <label>
+            <span>Descripcion del Arreglo Realizado</span>
+            <textarea rows="4" formControlName="description"></textarea>
+            @if (fieldError('description'); as error) {
+              <small class="field-error">{{ error }}</small>
+            }
+          </label>
+        </div>
+
+        <div class="form-grid four-columns">
+          <label>
+            <span>Tecnico que realiza el arreglo</span>
+            <select formControlName="technicianId">
+              @for (technician of technicians(); track technician.id) {
+                <option [value]="technician.id">{{ technician.name }}</option>
+              }
+            </select>
+            @if (fieldError('technicianId'); as error) {
+              <small class="field-error">{{ error }}</small>
+            }
+          </label>
+
+          <label>
+            <span>Costo del Arreglo (opcional)</span>
+            <input type="number" formControlName="cost" min="0" step="0.01" placeholder="1250.00">
+          </label>
+
+          <label>
+            <span>Observaciones (opcional)</span>
+            <input formControlName="observations" placeholder="Observaciones adicionales">
+          </label>
+        </div>
+
+        <div class="form-actions">
+          <button type="button" class="secondary" (click)="clearRepairForm()">Limpiar</button>
+          <button type="submit" class="primary" [disabled]="technicians().length === 0">Guardar Arreglo</button>
+        </div>
+      </form>
+    </article>
+
+    <article class="section-card">
+      <div class="history-header">
+        <div class="section-title">
+          <span class="section-icon">🕘</span>
+          <h3>Historico de Arreglos</h3>
+        </div>
+
+        <button type="button" class="secondary export-button" (click)="exportHistory()">Exportar</button>
+      </div>
+
+      <div class="history-table">
+        <div class="history-table__head">
+          <span>#</span>
+          <span>Fecha de Entrada</span>
+          <span>Fecha de Salida</span>
+          <span>Prioridad</span>
+          <span>Motivo / Falla</span>
+          <span>Descripcion del Arreglo</span>
+          <span>Tecnico</span>
+          <span>Costo</span>
+          <span>Observaciones</span>
+          <span>Estado</span>
+        </div>
+
+        @if (historyLoading()) {
+          <div class="history-table__empty">Cargando historial...</div>
+        } @else if (historyError()) {
+          <div class="history-table__empty">{{ historyError() }}</div>
+        } @else {
+        @for (record of selectedHistory(); track record.id; let index = $index) {
+          <div class="history-table__row">
+            <span>{{ selectedHistory().length - index }}</span>
+            <span>{{ formatDate(record.entryDate) }}</span>
+            <span>{{ formatDate(record.exitDate) }}</span>
+            <span>{{ record.priority }}</span>
+            <span>{{ record.issue }}</span>
+            <span>{{ record.description }}</span>
+            <span>{{ record.technicianName }}</span>
+            <span>{{ formatCost(record.cost) }}</span>
+            <span>{{ record.observations || '-' }}</span>
+            <span class="history-status">{{ record.status }}</span>
+          </div>
+        } @empty {
+          <div class="history-table__empty">Todavia no hay arreglos registrados para esta herramienta.</div>
+        }
+        }
+      </div>
+
+      <p class="history-footnote">
+        Mostrando {{ selectedHistory().length === 0 ? 0 : 1 }} a {{ selectedHistory().length }} de {{ selectedHistory().length }} registros
+      </p>
+    </article>
+  </section>
+}

--- a/src/app/pages/repairs/repairs-page.component.scss
+++ b/src/app/pages/repairs/repairs-page.component.scss
@@ -1,0 +1,298 @@
+.repairs-page {
+  display: grid;
+  gap: 1rem;
+}
+
+.repairs-header,
+.section-card,
+.empty-page {
+  padding: 1.2rem;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.84);
+  box-shadow: 0 16px 34px rgba(36, 50, 79, 0.09);
+}
+
+.repairs-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: end;
+  gap: 1rem;
+}
+
+.eyebrow {
+  margin: 0;
+  color: #4d77ef;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+h2,
+h3 {
+  margin: 0.25rem 0 0;
+  letter-spacing: -0.04em;
+}
+
+h2 {
+  font-size: 2rem;
+}
+
+h3 {
+  font-size: 1.35rem;
+}
+
+.intro {
+  margin: 0.65rem 0 0;
+  color: #63708b;
+}
+
+.tool-selector,
+label,
+.status-field,
+.image-field {
+  display: grid;
+  gap: 0.45rem;
+
+  span {
+    color: #556178;
+    font-size: 0.86rem;
+    font-weight: 800;
+  }
+}
+
+input,
+textarea,
+select {
+  width: 100%;
+  min-height: 3rem;
+  padding: 0.8rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(92, 106, 144, 0.14);
+  background: rgba(248, 250, 255, 0.96);
+  color: #22304a;
+  font: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+
+  &:focus {
+    outline: none;
+    border-color: rgba(70, 119, 246, 0.45);
+    box-shadow: 0 0 0 4px rgba(70, 119, 246, 0.12);
+  }
+}
+
+textarea {
+  resize: vertical;
+  min-height: 7rem;
+}
+
+.section-title {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.section-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.2rem;
+  height: 2.2rem;
+  border-radius: 999px;
+  background: #eef3ff;
+  font-size: 1.1rem;
+}
+
+.info-grid,
+.form-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.info-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.four-columns {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.two-columns {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.state-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 3rem;
+  padding: 0 1rem;
+  border-radius: 14px;
+  font-weight: 800;
+}
+
+.state-pill--available {
+  background: #eef7ea;
+  color: #2f7f37;
+}
+
+.state-pill--active {
+  background: #fff4df;
+  color: #b46a10;
+}
+
+.state-pill--maintenance {
+  background: #fff1f1;
+  color: #c23a3a;
+}
+
+.image-card {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+
+  img {
+    width: 102px;
+    height: 102px;
+    object-fit: contain;
+    border-radius: 16px;
+    border: 1px solid rgba(92, 106, 144, 0.14);
+    background: #fff;
+    padding: 0.4rem;
+  }
+}
+
+.image-edit,
+.primary,
+.secondary {
+  min-height: 3rem;
+  padding: 0 1.1rem;
+  border-radius: 14px;
+  font-weight: 800;
+  font: inherit;
+}
+
+.image-edit {
+  border: 1px solid rgba(92, 106, 144, 0.14);
+  background: #fff;
+  color: #33405f;
+}
+
+.field-error {
+  color: #b43333;
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.form-actions,
+.history-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.form-actions {
+  justify-content: flex-end;
+  margin-top: 1rem;
+}
+
+.primary {
+  border: none;
+  background: linear-gradient(135deg, #1745a7, #0f3690);
+  color: #fff;
+}
+
+.secondary {
+  border: 1px solid rgba(92, 106, 144, 0.14);
+  background: #fff;
+  color: #33405f;
+}
+
+.history-table {
+  margin-top: 1rem;
+  border: 1px solid rgba(84, 101, 144, 0.12);
+  border-radius: 18px;
+  overflow: hidden;
+  background: #fbfcff;
+}
+
+.history-table__head,
+.history-table__row {
+  display: grid;
+  grid-template-columns: 46px 120px 120px 94px 1.05fr 1.5fr 150px 110px 1fr 100px;
+  gap: 0;
+}
+
+.history-table__head {
+  background: linear-gradient(180deg, #14356f 0%, #0d2a5a 100%);
+  color: #fff;
+  font-size: 0.8rem;
+  font-weight: 800;
+}
+
+.history-table__head span,
+.history-table__row span {
+  padding: 0.95rem 0.85rem;
+  border-right: 1px solid rgba(84, 101, 144, 0.08);
+}
+
+.history-table__row {
+  align-items: stretch;
+  border-top: 1px solid rgba(84, 101, 144, 0.1);
+  color: #30405d;
+  background: #fff;
+}
+
+.history-status {
+  color: #2f7f37;
+  font-weight: 800;
+}
+
+.history-table__empty {
+  padding: 1rem;
+  text-align: center;
+  color: #66718c;
+}
+
+.history-footnote {
+  margin: 1rem 0 0;
+  color: #66718c;
+}
+
+.empty-page {
+  text-align: center;
+  color: #66718c;
+}
+
+@media (max-width: 1180px) {
+  .info-grid,
+  .four-columns {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .history-table {
+    overflow-x: auto;
+  }
+
+  .history-table__head,
+  .history-table__row {
+    min-width: 1320px;
+  }
+}
+
+@media (max-width: 860px) {
+  .repairs-header,
+  .history-header,
+  .form-actions,
+  .two-columns {
+    grid-template-columns: 1fr;
+    display: grid;
+  }
+
+  .info-grid,
+  .four-columns {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/app/pages/repairs/repairs-page.component.ts
+++ b/src/app/pages/repairs/repairs-page.component.ts
@@ -1,0 +1,541 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  signal
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { Tool } from '../../models/tool.model';
+import { RepairPayload, RepairRecord } from '../../models/repair.model';
+import { LocationStoreService } from '../../services/location-store.service';
+import { TechnicianStoreService } from '../../services/technician-store.service';
+import { ToolStoreService } from '../../services/tool-store.service';
+import { ToolApiService } from '../../services/tool-api.service';
+import { ToastService } from '../../services/toast.service';
+
+interface ToolRepairMeta {
+  code: string;
+}
+
+@Component({
+  selector: 'app-repairs-page',
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './repairs-page.component.html',
+  styleUrl: './repairs-page.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class RepairsPageComponent {
+  protected readonly store = inject(ToolStoreService);
+  protected readonly toolApi = inject(ToolApiService);
+  protected readonly technicianStore = inject(TechnicianStoreService);
+  protected readonly locationStore = inject(LocationStoreService);
+  private readonly toastService = inject(ToastService);
+  private readonly formBuilder = new FormBuilder();
+
+  protected readonly selectedToolId = signal('');
+  protected readonly metaStore = signal<Record<string, ToolRepairMeta>>({});
+  protected readonly historyStore = signal<Record<string, RepairRecord[]>>({});
+  protected readonly historyLoading = signal(false);
+  protected readonly historyError = signal<string | null>(null);
+  protected readonly updatingLocation = signal(false);
+
+  protected readonly tools = computed(() => this.store.tools());
+  protected readonly technicians = computed(() => this.technicianStore.activeTechnicians());
+  protected readonly locationOptions = computed(() => {
+    const baseOptions = this.locationStore.locationNames();
+    const currentLocation = this.selectedTool()?.location?.trim() ?? '';
+
+    if (currentLocation && !baseOptions.includes(currentLocation)) {
+      return [currentLocation, ...baseOptions];
+    }
+
+    return baseOptions;
+  });
+  protected readonly selectedTool = computed(() => {
+    const tools = this.tools();
+    const selectedId = this.selectedToolId();
+
+    return tools.find((tool) => tool.id === selectedId) ?? tools[0] ?? null;
+  });
+  protected readonly selectedMeta = computed(() => {
+    const tool = this.selectedTool();
+
+    if (!tool) {
+      return null;
+    }
+
+    return this.metaStore()[tool.id] ?? null;
+  });
+  protected readonly selectedHistory = computed(() => {
+    const tool = this.selectedTool();
+
+    if (!tool) {
+      return [];
+    }
+
+    return this.historyStore()[tool.id] ?? [];
+  });
+
+  protected readonly repairForm = this.formBuilder.nonNullable.group({
+    entryDate: [this.getIsoDateFromOffset(0), [Validators.required]],
+    exitDate: [this.getIsoDateFromOffset(4), [Validators.required]],
+    status: ['Reparado', [Validators.required]],
+    priority: ['Normal', [Validators.required]],
+    issue: ['', [Validators.required, Validators.minLength(10)]],
+    description: ['', [Validators.required, Validators.minLength(20)]],
+    technicianId: ['', [Validators.required]],
+    cost: [null as number | null],
+    observations: ['']
+  });
+
+  private historyRequestToken = 0;
+
+  constructor() {
+    this.technicianStore.ensureLoaded();
+    this.locationStore.ensureLoaded();
+
+    effect(() => {
+      const tools = this.store.tools();
+
+      if (tools.length === 0) {
+        return;
+      }
+
+      if (!this.selectedToolId() || !tools.some((tool) => tool.id === this.selectedToolId())) {
+        this.selectedToolId.set(tools[0].id);
+      }
+
+      this.metaStore.update((current) => {
+        const next = { ...current };
+
+        tools.forEach((tool, index) => {
+          next[tool.id] ??= {
+            code: `HT-${String(index + 1).padStart(5, '0')}`
+          };
+        });
+
+        return next;
+      });
+    });
+
+    effect(() => {
+      const technicians = this.technicians();
+      const currentTechnicianId = this.repairForm.getRawValue().technicianId;
+
+      if (technicians.length === 0) {
+        this.repairForm.patchValue({ technicianId: '' }, { emitEvent: false });
+        return;
+      }
+
+      if (!currentTechnicianId || !technicians.some((item) => item.id === currentTechnicianId)) {
+        this.repairForm.patchValue({ technicianId: technicians[0].id }, { emitEvent: false });
+      }
+    });
+
+    effect(() => {
+      const tool = this.selectedTool();
+
+      if (!tool) {
+        return;
+      }
+
+      this.loadRepairHistory(tool.id);
+    });
+  }
+
+  protected selectTool(toolId: string): void {
+    this.selectedToolId.set(toolId);
+  }
+
+  protected updateLocation(value: string): void {
+    const tool = this.selectedTool();
+
+    if (!tool) {
+      return;
+    }
+
+    if (tool.location === value) {
+      return;
+    }
+
+    this.updatingLocation.set(true);
+
+    this.toolApi.updateTool(tool.id, {
+      ...tool,
+      location: value
+    }).subscribe({
+      next: (updatedTool) => {
+        this.store.tools.update((current) =>
+          current.map((item) => item.id === updatedTool.id ? updatedTool : item)
+        );
+        this.toastService.show({
+          title: 'Ubicacion actualizada',
+          message: `${tool.name} ahora figura en "${value}".`,
+          tone: 'success'
+        });
+        this.updatingLocation.set(false);
+      },
+      error: (error: unknown) => {
+        this.toastService.show({
+          title: 'No se pudo actualizar la ubicacion',
+          message: this.extractErrorMessage(error),
+          tone: 'error'
+        });
+        this.updatingLocation.set(false);
+      }
+    });
+  }
+
+  protected openSelectedToolEditor(): void {
+    const tool = this.selectedTool();
+
+    if (!tool) {
+      return;
+    }
+
+    this.store.openEditModal(tool);
+  }
+
+  protected clearRepairForm(): void {
+    this.repairForm.reset({
+      entryDate: this.getIsoDateFromOffset(0),
+      exitDate: this.getIsoDateFromOffset(4),
+      status: 'Reparado',
+      priority: 'Normal',
+      issue: '',
+      description: '',
+      technicianId: this.technicians()[0]?.id ?? '',
+      cost: null,
+      observations: ''
+    });
+  }
+
+  protected saveRepair(): void {
+    const tool = this.selectedTool();
+
+    if (!tool) {
+      this.toastService.show({
+        title: 'Selecciona una herramienta',
+        message: 'Necesitas elegir una herramienta antes de registrar un arreglo.',
+        tone: 'warning'
+      });
+      return;
+    }
+
+    if (this.technicians().length === 0) {
+      this.toastService.show({
+        title: 'Sin tecnicos disponibles',
+        message: 'Debes registrar al menos un tecnico activo antes de guardar un arreglo.',
+        tone: 'warning'
+      });
+      return;
+    }
+
+    if (this.repairForm.invalid) {
+      this.repairForm.markAllAsTouched();
+      this.toastService.show({
+        title: 'Formulario incompleto',
+        message: 'Revisa los campos obligatorios del arreglo antes de guardar.',
+        tone: 'warning'
+      });
+      return;
+    }
+
+    const raw = this.repairForm.getRawValue();
+    const payload: RepairPayload = {
+      entryDate: raw.entryDate,
+      exitDate: raw.exitDate,
+      status: raw.status,
+      priority: raw.priority,
+      issue: raw.issue,
+      description: raw.description,
+      technicianId: raw.technicianId,
+      cost: this.normalizeCost(raw.cost),
+      observations: raw.observations
+    };
+
+    this.toolApi.createToolRepair(tool.id, payload).subscribe({
+      next: (record) => {
+        this.historyStore.update((current) => ({
+          ...current,
+          [tool.id]: [record, ...(current[tool.id] ?? [])]
+        }));
+
+        this.clearRepairForm();
+
+        this.toastService.show({
+          title: 'Arreglo registrado',
+          message: `Se ha guardado un nuevo registro de arreglo para ${tool.name}.`,
+          tone: 'success'
+        });
+      },
+      error: (error: unknown) => {
+        this.toastService.show({
+          title: 'No se pudo guardar el arreglo',
+          message: this.extractErrorMessage(error),
+          tone: 'error'
+        });
+      }
+    });
+  }
+
+  protected exportHistory(): void {
+    const tool = this.selectedTool();
+    const history = this.selectedHistory();
+
+    if (!tool || history.length === 0) {
+      this.toastService.show({
+        title: 'Sin datos para exportar',
+        message: 'Esta herramienta todavia no tiene historial de arreglos.',
+        tone: 'info'
+      });
+      return;
+    }
+
+    this.generateHistoryPdf(tool, history).catch(() => {
+      this.toastService.show({
+        title: 'No se pudo exportar',
+        message: 'Hubo un problema al generar el PDF del historial.',
+        tone: 'error'
+      });
+    });
+  }
+
+  protected getToolStateTone(state: string): 'available' | 'active' | 'maintenance' {
+    const normalized = state.trim().toLowerCase();
+
+    if (normalized.includes('mant') || normalized.includes('repar')) {
+      return 'maintenance';
+    }
+
+    if (normalized.includes('uso') || normalized.includes('prest') || normalized.includes('obra')) {
+      return 'active';
+    }
+
+    return 'available';
+  }
+
+  protected fieldError(name: keyof ReturnType<typeof this.repairForm.getRawValue>): string | null {
+    const control = this.repairForm.get(name);
+
+    if (!control || !control.invalid || !control.touched) {
+      return null;
+    }
+
+    if (control.errors?.['required']) {
+      return 'Este campo es obligatorio.';
+    }
+
+    if (control.errors?.['minlength']) {
+      return `Debe tener al menos ${control.errors['minlength'].requiredLength} caracteres.`;
+    }
+
+    return 'Valor no valido.';
+  }
+
+  protected formatDate(value: string): string {
+    const [year, month, day] = value.split('-');
+    return `${day}/${month}/${year}`;
+  }
+
+  protected formatCost(value: number | null): string {
+    if (value === null) {
+      return 'Sin coste';
+    }
+
+    return new Intl.NumberFormat('es-ES', {
+      style: 'currency',
+      currency: 'USD',
+      minimumFractionDigits: 2
+    }).format(value);
+  }
+
+  private getIsoDateFromOffset(offsetDays: number): string {
+    const date = new Date();
+    date.setDate(date.getDate() + offsetDays);
+    return date.toISOString().slice(0, 10);
+  }
+
+  private normalizeCost(value: string | number | null): number | null {
+    if (value === null || value === undefined || value === '') {
+      return null;
+    }
+
+    if (typeof value === 'number') {
+      return Number.isFinite(value) ? value : null;
+    }
+
+    const normalized = value.trim();
+
+    if (normalized === '') {
+      return null;
+    }
+
+    const parsed = Number(normalized.replace(',', '.'));
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  private async generateHistoryPdf(tool: Tool, history: RepairRecord[]): Promise<void> {
+    const [{ jsPDF }, { default: autoTable }] = await Promise.all([
+      import('jspdf'),
+      import('jspdf-autotable')
+    ]);
+
+    const document = new jsPDF({ unit: 'pt', format: 'a4' }) as any;
+    const exportedAt = new Date().toLocaleString('es-ES');
+
+    document.setFillColor(20, 53, 111);
+    document.rect(0, 0, document.internal.pageSize.getWidth(), 88, 'F');
+    document.setTextColor(255, 255, 255);
+    document.setFont('helvetica', 'bold');
+    document.setFontSize(21);
+    document.text('Historico de Arreglos', 40, 40);
+    document.setFont('helvetica', 'normal');
+    document.setFontSize(10);
+    document.text(`Generado el ${exportedAt}`, 40, 60);
+
+    document.setTextColor(30, 41, 59);
+
+    autoTable(document, {
+      startY: 108,
+      theme: 'grid',
+      head: [['Dato', 'Valor', 'Dato', 'Valor']],
+      body: [
+        ['Codigo / ID', this.selectedMeta()?.code ?? tool.id, 'Nombre', tool.name],
+        ['Marca', tool.brand, 'Modelo', tool.model],
+        ['Numero de Serie', tool.serialNumber, 'Ubicacion', tool.location],
+        ['Categoria', tool.category, 'Tipo', tool.type],
+        ['Estado actual', tool.state, 'Material', tool.material]
+      ],
+      headStyles: {
+        fillColor: [77, 119, 239]
+      },
+      styles: {
+        fontSize: 9,
+        cellPadding: 7
+      },
+      columnStyles: {
+        0: { fontStyle: 'bold' },
+        2: { fontStyle: 'bold' }
+      }
+    });
+
+    autoTable(document, {
+      startY: (document.lastAutoTable?.finalY ?? 108) + 20,
+      theme: 'grid',
+      head: [[
+        '#',
+        'Entrada',
+        'Salida',
+        'Estado',
+        'Prioridad',
+        'Tecnico',
+        'Costo',
+        'Motivo / Falla',
+        'Descripcion',
+        'Observaciones'
+      ]],
+      body: history.map((record, index) => [
+        String(history.length - index),
+        this.formatDate(record.entryDate),
+        this.formatDate(record.exitDate),
+        record.status,
+        record.priority,
+        record.technicianName,
+        this.formatCost(record.cost),
+        record.issue,
+        record.description,
+        record.observations || '-'
+      ]),
+      headStyles: {
+        fillColor: [20, 53, 111]
+      },
+      styles: {
+        fontSize: 8,
+        cellPadding: 6,
+        overflow: 'linebreak',
+        valign: 'top'
+      },
+      columnStyles: {
+        0: { cellWidth: 26, halign: 'center' },
+        1: { cellWidth: 52 },
+        2: { cellWidth: 52 },
+        3: { cellWidth: 55 },
+        4: { cellWidth: 54 },
+        5: { cellWidth: 72 },
+        6: { cellWidth: 60 },
+        7: { cellWidth: 92 },
+        8: { cellWidth: 125 },
+        9: { cellWidth: 95 }
+      }
+    });
+
+    const fileName = `historial-arreglos-${tool.name.toLowerCase().replaceAll(' ', '-')}.pdf`;
+    document.save(fileName);
+
+    this.toastService.show({
+      title: 'PDF generado',
+      message: 'El historial de arreglos se ha exportado correctamente.',
+      tone: 'success'
+    });
+  }
+
+  private loadRepairHistory(toolId: string): void {
+    if (this.historyStore()[toolId]) {
+      this.historyError.set(null);
+      return;
+    }
+
+    const requestToken = ++this.historyRequestToken;
+    this.historyLoading.set(true);
+    this.historyError.set(null);
+
+    this.toolApi.getToolRepairs(toolId).subscribe({
+      next: (history) => {
+        if (requestToken !== this.historyRequestToken) {
+          return;
+        }
+
+        this.historyStore.update((current) => ({
+          ...current,
+          [toolId]: history
+        }));
+        this.historyLoading.set(false);
+      },
+      error: (error: unknown) => {
+        if (requestToken !== this.historyRequestToken) {
+          return;
+        }
+
+        this.historyLoading.set(false);
+        this.historyError.set(this.extractErrorMessage(error));
+      }
+    });
+  }
+
+  private extractErrorMessage(error: unknown): string {
+    if (typeof error === 'object' && error !== null && 'error' in error) {
+      const payload = (error as {
+        error?: { message?: string; errors?: string[] };
+        message?: string;
+      }).error;
+
+      if (Array.isArray(payload?.errors) && payload.errors.length > 0) {
+        return payload.errors.join(' ');
+      }
+
+      if (typeof payload?.message === 'string' && payload.message.trim() !== '') {
+        return payload.message;
+      }
+    }
+
+    if (error instanceof Error && error.message.trim() !== '') {
+      return error.message;
+    }
+
+    return 'Ha ocurrido un error inesperado.';
+  }
+}

--- a/src/app/pages/reports/reports-page.component.html
+++ b/src/app/pages/reports/reports-page.component.html
@@ -256,7 +256,7 @@
               ? 'Disponible'
               : reportMetrics().activeRate >= reportMetrics().maintenanceRate
                 ? 'En uso'
-                : 'Mantenimiento'
+                : 'En mantenimiento'
           }}
         </strong>
       </div>

--- a/src/app/pages/reports/reports-page.component.ts
+++ b/src/app/pages/reports/reports-page.component.ts
@@ -42,7 +42,7 @@ export class ReportsPageComponent implements OnDestroy {
     { value: 'all', label: 'Todos los estados' },
     { value: 'available', label: 'Disponible' },
     { value: 'active', label: 'En uso' },
-    { value: 'maintenance', label: 'Mantenimiento' }
+    { value: 'maintenance', label: 'En mantenimiento' }
   ] as const;
 
   protected readonly reportBaseTools = computed(() => this.store.filteredTools());
@@ -127,7 +127,7 @@ export class ReportsPageComponent implements OnDestroy {
     const metrics = this.reportMetrics();
 
     return {
-      labels: ['Disponible', 'En uso', 'Mantenimiento'],
+      labels: ['Disponible', 'En uso', 'En mantenimiento'],
       datasets: [
         {
           data: [
@@ -512,7 +512,7 @@ export class ReportsPageComponent implements OnDestroy {
             ['Total herramientas', metrics.totalTools],
             ['Disponibilidad', `${metrics.availableRate}%`],
             ['En uso', `${metrics.activeRate}%`],
-            ['Mantenimiento', `${metrics.maintenanceRate}%`],
+            ['En mantenimiento', `${metrics.maintenanceRate}%`],
             ['Promedio longitud', `${metrics.averageLong} cm`]
           );
         }
@@ -688,7 +688,7 @@ export class ReportsPageComponent implements OnDestroy {
           ['Total herramientas', String(metrics.totalTools)],
           ['Disponibilidad', `${metrics.availableRate}%`],
           ['En uso', `${metrics.activeRate}%`],
-          ['Mantenimiento', `${metrics.maintenanceRate}%`],
+          ['En mantenimiento', `${metrics.maintenanceRate}%`],
           ['Promedio longitud', `${metrics.averageLong} cm`]
         ],
         theme: 'grid',

--- a/src/app/pages/settings/settings-page.component.html
+++ b/src/app/pages/settings/settings-page.component.html
@@ -39,13 +39,224 @@
   </article>
 
   <article class="settings-card span-two">
+    <p class="eyebrow">Catalogos</p>
+    <h3>Gestion de Ubicaciones</h3>
+
+    <div class="locations-layout">
+      <form class="location-form" [formGroup]="locationForm" (ngSubmit)="saveLocation()">
+        <label>
+          <span>Nombre</span>
+          <input formControlName="name" placeholder="Ej. Almacen Central">
+          @if (locationFieldError('name'); as error) {
+            <small class="field-error">{{ error }}</small>
+          }
+        </label>
+
+        <label>
+          <span>Descripcion</span>
+          <textarea rows="4" formControlName="description" placeholder="Observaciones opcionales"></textarea>
+        </label>
+
+        @if (locationStore.saveError()) {
+          <div class="form-alert">{{ locationStore.saveError() }}</div>
+        }
+
+        <div class="form-actions">
+          @if (editingLocation()) {
+            <button type="button" class="secondary-button" (click)="cancelLocationEdit()">Cancelar</button>
+          }
+          <button type="submit" class="primary-button" [disabled]="locationStore.saving()">
+            {{ locationStore.saving() ? 'Guardando...' : editingLocation() ? 'Guardar cambios' : 'Anadir ubicacion' }}
+          </button>
+        </div>
+      </form>
+
+      <div class="locations-panel">
+        <div class="panel-header">
+          <strong>Ubicaciones configuradas</strong>
+          <span>{{ locations().length }} registradas</span>
+        </div>
+
+        @if (locationStore.loading()) {
+          <div class="empty-box">Cargando ubicaciones...</div>
+        } @else if (locations().length === 0) {
+          <div class="empty-box">Todavia no hay ubicaciones configuradas.</div>
+        } @else {
+          <div class="locations-list">
+            @for (location of locations(); track location.id) {
+              <article class="location-item">
+                <div>
+                  <strong>{{ location.name }}</strong>
+                  <p>{{ location.description || 'Sin descripcion adicional.' }}</p>
+                </div>
+
+                <div class="location-actions">
+                  <button type="button" class="secondary-button" (click)="startEditLocation(location)">Editar</button>
+                  <button type="button" class="danger-button" (click)="locationStore.deleteLocation(location)">Eliminar</button>
+                </div>
+              </article>
+            }
+          </div>
+        }
+      </div>
+    </div>
+  </article>
+
+  <article class="settings-card span-two">
+    <p class="eyebrow">Catalogos</p>
+    <h3>Gestion de Tipos de Herramienta</h3>
+
+    <div class="locations-layout">
+      <form class="location-form" [formGroup]="toolTypeForm" (ngSubmit)="saveToolType()">
+        <label>
+          <span>Nombre</span>
+          <input formControlName="name" placeholder="Ej. Corte, Manual, Electrica">
+          @if (toolTypeFieldError('name'); as error) {
+            <small class="field-error">{{ error }}</small>
+          }
+        </label>
+
+        <label>
+          <span>Descripcion</span>
+          <textarea rows="4" formControlName="description" placeholder="Observaciones opcionales"></textarea>
+        </label>
+
+        @if (toolTypeStore.saveError()) {
+          <div class="form-alert">{{ toolTypeStore.saveError() }}</div>
+        }
+
+        <div class="form-actions">
+          @if (editingToolType()) {
+            <button type="button" class="secondary-button" (click)="cancelToolTypeEdit()">Cancelar</button>
+          }
+          <button type="submit" class="primary-button" [disabled]="toolTypeStore.saving()">
+            {{ toolTypeStore.saving() ? 'Guardando...' : editingToolType() ? 'Guardar cambios' : 'Anadir tipo' }}
+          </button>
+        </div>
+      </form>
+
+      <div class="locations-panel">
+        <div class="panel-header">
+          <strong>Tipos configurados</strong>
+          <span>{{ toolTypes().length }} registrados</span>
+        </div>
+
+        @if (toolTypeStore.loading()) {
+          <div class="empty-box">Cargando tipos...</div>
+        } @else if (toolTypes().length === 0) {
+          <div class="empty-box">Todavia no hay tipos configurados.</div>
+        } @else {
+          <div class="locations-list">
+            @for (toolType of toolTypes(); track toolType.id) {
+              <article class="location-item">
+                <div>
+                  <strong>{{ toolType.name }}</strong>
+                  <p>{{ toolType.description || 'Sin descripcion adicional.' }}</p>
+                </div>
+
+                <div class="location-actions">
+                  <button type="button" class="secondary-button" (click)="startEditToolType(toolType)">Editar</button>
+                  <button type="button" class="danger-button" (click)="toolTypeStore.deleteToolType(toolType)">Eliminar</button>
+                </div>
+              </article>
+            }
+          </div>
+        }
+      </div>
+    </div>
+  </article>
+
+  <article class="settings-card span-two">
+    <div class="catalog-header">
+      <div>
+        <p class="eyebrow">Catalogos</p>
+        <h3>Gestion de Tecnicos</h3>
+        <p class="catalog-intro">Administra el equipo que podra seleccionarse al registrar arreglos.</p>
+      </div>
+
+      <button type="button" class="primary-button" (click)="technicianStore.openCreateModal()">
+        ＋ Anadir tecnico
+      </button>
+    </div>
+
+    <div class="summary-grid">
+      <article class="summary-card">
+        <span class="summary-label">Tecnicos registrados</span>
+        <strong>{{ technicianTotals().total }}</strong>
+      </article>
+
+      <article class="summary-card summary-card--accent">
+        <span class="summary-label">Disponibles para arreglos</span>
+        <strong>{{ technicianTotals().active }}</strong>
+      </article>
+    </div>
+
+    <div class="technicians-card">
+      <div class="panel-header">
+        <strong>Equipo tecnico</strong>
+        <span>Solo los tecnicos activos apareceran en los arreglos.</span>
+      </div>
+
+      @if (technicianStore.loading()) {
+        <div class="empty-box">Cargando tecnicos...</div>
+      } @else if (technicians().length === 0) {
+        <div class="empty-box">Todavia no hay tecnicos registrados.</div>
+      } @else {
+        <div class="table-wrap">
+          <div class="tech-table">
+            <div class="tech-table__head">
+              <span>Nombre</span>
+              <span>Especialidad</span>
+              <span>Telefono</span>
+              <span>Correo</span>
+              <span>Estado</span>
+              <span>Acciones</span>
+            </div>
+
+            @for (technician of technicians(); track technician.id) {
+              <div class="tech-table__row">
+                <span class="primary-cell">{{ technician.name }}</span>
+                <span>{{ technician.specialty }}</span>
+                <span>{{ technician.phone || '-' }}</span>
+                <span>{{ technician.email || '-' }}</span>
+                <span>
+                  <span class="state-pill" [class.state-pill--inactive]="!technician.active">
+                    {{ technicianStateLabel(technician.active) }}
+                  </span>
+                </span>
+                <span class="actions-cell">
+                  <button type="button" class="secondary-button small-button" (click)="technicianStore.openEditModal(technician)">
+                    Editar
+                  </button>
+                  <button type="button" class="danger-button small-button" (click)="technicianStore.deleteTechnician(technician)">
+                    Eliminar
+                  </button>
+                </span>
+              </div>
+            }
+          </div>
+        </div>
+      }
+    </div>
+  </article>
+
+  <article class="settings-card span-two">
     <p class="eyebrow">Entorno</p>
     <h3>Notas de operacion</h3>
     <ul class="notes">
       <li>La app no usa autenticacion en esta version.</li>
       <li>Las imagenes se cargan a Firebase Storage a traves del backend.</li>
       <li>El dashboard, inventario, categorias y reportes comparten el mismo buscador global.</li>
+      <li>Las ubicaciones configuradas aqui se reutilizan en herramientas y arreglos.</li>
     </ul>
   </article>
 </section>
 
+<app-technician-form-modal
+  [visible]="technicianStore.modalOpen()"
+  [technician]="technicianStore.editingTechnician()"
+  [saving]="technicianStore.saving()"
+  [saveError]="technicianStore.saveError()"
+  (closed)="technicianStore.closeModal()"
+  (submitted)="technicianStore.saveTechnician($event)"
+/>

--- a/src/app/pages/settings/settings-page.component.scss
+++ b/src/app/pages/settings/settings-page.component.scss
@@ -30,6 +30,49 @@ h3 {
   letter-spacing: -0.04em;
 }
 
+.catalog-header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.catalog-intro {
+  margin: 0.55rem 0 0;
+  color: #63708b;
+}
+
+label {
+  display: grid;
+  gap: 0.45rem;
+
+  span {
+    color: #556178;
+    font-size: 0.82rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+}
+
+input,
+textarea {
+  width: 100%;
+  min-height: 3rem;
+  padding: 0.8rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(92, 106, 144, 0.14);
+  background: rgba(248, 250, 255, 0.96);
+  color: #22304a;
+  font: inherit;
+}
+
+textarea {
+  resize: vertical;
+  min-height: 7rem;
+}
+
 .toggle-row {
   display: flex;
   align-items: center;
@@ -95,6 +138,224 @@ h3 {
   }
 }
 
+.locations-layout {
+  display: grid;
+  grid-template-columns: minmax(280px, 360px) 1fr;
+  gap: 1rem;
+}
+
+.location-form,
+.locations-panel {
+  padding: 1rem;
+  border-radius: 20px;
+  background: #fbfcff;
+  border: 1px solid rgba(86, 101, 138, 0.12);
+}
+
+.location-form {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.9rem;
+
+  span {
+    color: #68758f;
+  }
+}
+
+.summary-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-bottom: 1rem;
+}
+
+.summary-card {
+  display: grid;
+  gap: 0.35rem;
+  padding: 1rem;
+  border-radius: 20px;
+  background: #fbfcff;
+  border: 1px solid rgba(86, 101, 138, 0.12);
+
+  strong {
+    font-size: 2rem;
+    color: #1f3156;
+  }
+}
+
+.summary-card--accent {
+  background: linear-gradient(135deg, rgba(71, 119, 246, 0.12), rgba(53, 162, 141, 0.14));
+}
+
+.summary-label {
+  color: #60708d;
+  font-weight: 800;
+}
+
+.technicians-card {
+  padding: 1rem;
+  border-radius: 20px;
+  background: #fbfcff;
+  border: 1px solid rgba(86, 101, 138, 0.12);
+}
+
+.table-wrap {
+  margin-top: 1rem;
+  overflow-x: auto;
+}
+
+.tech-table {
+  min-width: 920px;
+  border: 1px solid rgba(84, 101, 144, 0.12);
+  border-radius: 18px;
+  overflow: hidden;
+  background: #fff;
+}
+
+.tech-table__head,
+.tech-table__row {
+  display: grid;
+  grid-template-columns: 1.3fr 1fr 140px 1.2fr 120px 220px;
+}
+
+.tech-table__head {
+  background: linear-gradient(180deg, #14356f 0%, #0d2a5a 100%);
+  color: #fff;
+  font-size: 0.8rem;
+  font-weight: 800;
+}
+
+.tech-table__head span,
+.tech-table__row span {
+  padding: 0.95rem 0.85rem;
+  border-right: 1px solid rgba(84, 101, 144, 0.08);
+}
+
+.tech-table__row {
+  align-items: center;
+  border-top: 1px solid rgba(84, 101, 144, 0.1);
+  color: #30405d;
+  background: #fff;
+}
+
+.primary-cell {
+  font-weight: 800;
+}
+
+.state-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 84px;
+  min-height: 2.2rem;
+  padding: 0 0.85rem;
+  border-radius: 999px;
+  background: #eef7ea;
+  color: #2f7f37;
+  font-weight: 800;
+}
+
+.state-pill--inactive {
+  background: #fff4df;
+  color: #b46a10;
+}
+
+.actions-cell {
+  display: flex;
+  gap: 0.65rem;
+  align-items: center;
+}
+
+.locations-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.location-item {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.95rem 1rem;
+  border-radius: 16px;
+  background: #fff;
+  border: 1px solid rgba(86, 101, 138, 0.1);
+
+  p {
+    margin: 0.35rem 0 0;
+    color: #69748d;
+    line-height: 1.45;
+  }
+}
+
+.location-actions,
+.form-actions {
+  display: flex;
+  gap: 0.65rem;
+  justify-content: flex-end;
+}
+
+.primary-button,
+.secondary-button,
+.danger-button {
+  min-height: 2.8rem;
+  padding: 0 1rem;
+  border-radius: 12px;
+  border: none;
+  font: inherit;
+  font-weight: 800;
+}
+
+.small-button {
+  min-height: 2.6rem;
+  padding-inline: 0.9rem;
+}
+
+.primary-button {
+  background: linear-gradient(135deg, #1745a7, #0f3690);
+  color: #fff;
+}
+
+.secondary-button {
+  background: #eef2ff;
+  color: #224aa5;
+}
+
+.danger-button {
+  background: #fff1f1;
+  color: #ba3131;
+}
+
+.empty-box,
+.form-alert,
+.field-error {
+  color: #66718c;
+}
+
+.empty-box {
+  padding: 1rem;
+  border-radius: 16px;
+  background: #f6f8fe;
+  text-align: center;
+}
+
+.form-alert,
+.field-error {
+  font-size: 0.82rem;
+}
+
+.form-alert,
+.field-error {
+  color: #b43333;
+}
+
 .notes {
   margin: 0;
   padding-left: 1.2rem;
@@ -113,5 +374,14 @@ h3 {
   .span-two {
     grid-column: span 1;
   }
-}
 
+  .catalog-header,
+  .summary-grid,
+  .locations-layout,
+  .location-item,
+  .location-actions,
+  .form-actions {
+    grid-template-columns: 1fr;
+    display: grid;
+  }
+}

--- a/src/app/pages/settings/settings-page.component.ts
+++ b/src/app/pages/settings/settings-page.component.ts
@@ -1,16 +1,159 @@
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { TechnicianFormModalComponent } from '../../components/technician-form-modal.component';
+import { ToolLocation } from '../../models/location.model';
+import { ToolType } from '../../models/tool-type.model';
+import { LocationStoreService } from '../../services/location-store.service';
+import { TechnicianStoreService } from '../../services/technician-store.service';
+import { ToolTypeStoreService } from '../../services/tool-type-store.service';
 
 @Component({
   selector: 'app-settings-page',
-  imports: [CommonModule],
+  imports: [CommonModule, ReactiveFormsModule, TechnicianFormModalComponent],
   templateUrl: './settings-page.component.html',
   styleUrl: './settings-page.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SettingsPageComponent {
+  private readonly formBuilder = new FormBuilder();
+  protected readonly locationStore = inject(LocationStoreService);
+  protected readonly technicianStore = inject(TechnicianStoreService);
+  protected readonly toolTypeStore = inject(ToolTypeStoreService);
+
   protected readonly compactMode = signal(false);
   protected readonly reducedAnimations = signal(false);
   protected readonly showDemoFallback = signal(true);
-}
+  protected readonly editingLocation = signal<ToolLocation | null>(null);
+  protected readonly editingToolType = signal<ToolType | null>(null);
+  protected readonly locations = computed(() => this.locationStore.locations());
+  protected readonly toolTypes = computed(() => this.toolTypeStore.toolTypes());
+  protected readonly technicians = computed(() => this.technicianStore.technicians());
+  protected readonly technicianTotals = computed(() => ({
+    total: this.technicianStore.technicians().length,
+    active: this.technicianStore.activeTechnicians().length
+  }));
 
+  protected readonly locationForm = this.formBuilder.nonNullable.group({
+    name: ['', [Validators.required]],
+    description: ['']
+  });
+  protected readonly toolTypeForm = this.formBuilder.nonNullable.group({
+    name: ['', [Validators.required]],
+    description: ['']
+  });
+
+  constructor() {
+    this.locationStore.ensureLoaded();
+    this.technicianStore.ensureLoaded();
+    this.toolTypeStore.ensureLoaded();
+  }
+
+  protected startCreateLocation(): void {
+    this.editingLocation.set(null);
+    this.locationForm.reset({
+      name: '',
+      description: ''
+    });
+  }
+
+  protected startEditLocation(location: ToolLocation): void {
+    this.editingLocation.set(location);
+    this.locationForm.reset({
+      name: location.name,
+      description: location.description
+    });
+  }
+
+  protected cancelLocationEdit(): void {
+    this.startCreateLocation();
+  }
+
+  protected saveLocation(): void {
+    if (this.locationForm.invalid) {
+      this.locationForm.markAllAsTouched();
+      return;
+    }
+
+    const editing = this.editingLocation();
+
+    this.locationStore.saveLocation(
+      this.locationForm.getRawValue(),
+      editing?.id
+    ).then(() => {
+      this.startCreateLocation();
+    }).catch(() => {
+      return;
+    });
+  }
+
+  protected startCreateToolType(): void {
+    this.editingToolType.set(null);
+    this.toolTypeForm.reset({
+      name: '',
+      description: ''
+    });
+  }
+
+  protected startEditToolType(toolType: ToolType): void {
+    this.editingToolType.set(toolType);
+    this.toolTypeForm.reset({
+      name: toolType.name,
+      description: toolType.description
+    });
+  }
+
+  protected cancelToolTypeEdit(): void {
+    this.startCreateToolType();
+  }
+
+  protected saveToolType(): void {
+    if (this.toolTypeForm.invalid) {
+      this.toolTypeForm.markAllAsTouched();
+      return;
+    }
+
+    const editing = this.editingToolType();
+
+    this.toolTypeStore.saveToolType(
+      this.toolTypeForm.getRawValue(),
+      editing?.id
+    ).then(() => {
+      this.startCreateToolType();
+    }).catch(() => {
+      return;
+    });
+  }
+
+  protected locationFieldError(name: 'name' | 'description'): string | null {
+    const control = this.locationForm.get(name);
+
+    if (!control || !control.invalid || !control.touched) {
+      return null;
+    }
+
+    if (control.errors?.['required']) {
+      return 'Este campo es obligatorio.';
+    }
+
+    return 'Valor no valido.';
+  }
+
+  protected toolTypeFieldError(name: 'name' | 'description'): string | null {
+    const control = this.toolTypeForm.get(name);
+
+    if (!control || !control.invalid || !control.touched) {
+      return null;
+    }
+
+    if (control.errors?.['required']) {
+      return 'Este campo es obligatorio.';
+    }
+
+    return 'Valor no valido.';
+  }
+
+  protected technicianStateLabel(active: boolean): string {
+    return active ? 'Activo' : 'Inactivo';
+  }
+}

--- a/src/app/pages/technicians/technicians-page.component.html
+++ b/src/app/pages/technicians/technicians-page.component.html
@@ -1,0 +1,84 @@
+<section class="technicians-page">
+  <header class="page-header">
+    <div>
+      <p class="eyebrow">Soporte Tecnico</p>
+      <h2>Gestion de Tecnicos</h2>
+      <p class="intro">Administra el equipo que podra asignarse a los arreglos de herramientas.</p>
+    </div>
+
+    <button type="button" class="primary" (click)="technicianStore.openCreateModal()">
+      ＋ Anadir Tecnico
+    </button>
+  </header>
+
+  <section class="summary-grid">
+    <article class="summary-card">
+      <span class="summary-label">Tecnicos registrados</span>
+      <strong>{{ totals().total }}</strong>
+    </article>
+
+    <article class="summary-card summary-card--accent">
+      <span class="summary-label">Disponibles para arreglos</span>
+      <strong>{{ totals().active }}</strong>
+    </article>
+  </section>
+
+  <section class="table-card">
+    <div class="table-toolbar">
+      <div>
+        <h3>Equipo tecnico</h3>
+        <p>Solo los tecnicos activos apareceran para elegirlos al registrar un arreglo.</p>
+      </div>
+    </div>
+
+    @if (technicianStore.loading()) {
+      <div class="empty-state">Cargando tecnicos...</div>
+    } @else if (technicians().length === 0) {
+      <div class="empty-state">Todavia no hay tecnicos registrados.</div>
+    } @else {
+      <div class="table-wrap">
+        <div class="tech-table">
+          <div class="tech-table__head">
+            <span>Nombre</span>
+            <span>Especialidad</span>
+            <span>Telefono</span>
+            <span>Correo</span>
+            <span>Estado</span>
+            <span>Acciones</span>
+          </div>
+
+          @for (technician of technicians(); track technician.id) {
+            <div class="tech-table__row">
+              <span class="primary-cell">{{ technician.name }}</span>
+              <span>{{ technician.specialty }}</span>
+              <span>{{ technician.phone || '-' }}</span>
+              <span>{{ technician.email || '-' }}</span>
+              <span>
+                <span class="state-pill" [class.state-pill--inactive]="!technician.active">
+                  {{ technician.active ? 'Activo' : 'Inactivo' }}
+                </span>
+              </span>
+              <span class="actions-cell">
+                <button type="button" class="secondary small" (click)="technicianStore.openEditModal(technician)">
+                  Editar
+                </button>
+                <button type="button" class="danger small" (click)="technicianStore.deleteTechnician(technician)">
+                  Eliminar
+                </button>
+              </span>
+            </div>
+          }
+        </div>
+      </div>
+    }
+  </section>
+</section>
+
+<app-technician-form-modal
+  [visible]="technicianStore.modalOpen()"
+  [technician]="technicianStore.editingTechnician()"
+  [saving]="technicianStore.saving()"
+  [saveError]="technicianStore.saveError()"
+  (closed)="technicianStore.closeModal()"
+  (submitted)="technicianStore.saveTechnician($event)"
+/>

--- a/src/app/pages/technicians/technicians-page.component.scss
+++ b/src/app/pages/technicians/technicians-page.component.scss
@@ -1,0 +1,187 @@
+.technicians-page {
+  display: grid;
+  gap: 1rem;
+}
+
+.page-header,
+.summary-card,
+.table-card {
+  padding: 1.2rem;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.84);
+  box-shadow: 0 16px 34px rgba(36, 50, 79, 0.09);
+}
+
+.page-header,
+.table-toolbar {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.eyebrow {
+  margin: 0;
+  color: #4d77ef;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+h2,
+h3 {
+  margin: 0.25rem 0 0;
+  letter-spacing: -0.04em;
+}
+
+h2 {
+  font-size: 2rem;
+}
+
+.intro,
+.table-toolbar p {
+  margin: 0.65rem 0 0;
+  color: #63708b;
+}
+
+.summary-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.summary-card {
+  display: grid;
+  gap: 0.35rem;
+
+  strong {
+    font-size: 2rem;
+    color: #1f3156;
+  }
+}
+
+.summary-card--accent {
+  background: linear-gradient(135deg, rgba(71, 119, 246, 0.12), rgba(53, 162, 141, 0.14));
+}
+
+.summary-label {
+  color: #60708d;
+  font-weight: 800;
+}
+
+.primary,
+.secondary,
+.danger {
+  min-height: 3rem;
+  padding: 0 1.1rem;
+  border-radius: 14px;
+  font-weight: 800;
+  font: inherit;
+  border: none;
+}
+
+.primary {
+  background: linear-gradient(135deg, #1745a7, #0f3690);
+  color: #fff;
+}
+
+.secondary {
+  background: #edf2ff;
+  color: #224aa5;
+}
+
+.danger {
+  background: #fff1f1;
+  color: #ba3131;
+}
+
+.small {
+  min-height: 2.6rem;
+  padding-inline: 0.9rem;
+}
+
+.table-wrap {
+  margin-top: 1rem;
+  overflow-x: auto;
+}
+
+.tech-table {
+  min-width: 920px;
+  border: 1px solid rgba(84, 101, 144, 0.12);
+  border-radius: 18px;
+  overflow: hidden;
+  background: #fbfcff;
+}
+
+.tech-table__head,
+.tech-table__row {
+  display: grid;
+  grid-template-columns: 1.3fr 1fr 140px 1.2fr 120px 220px;
+}
+
+.tech-table__head {
+  background: linear-gradient(180deg, #14356f 0%, #0d2a5a 100%);
+  color: #fff;
+  font-size: 0.8rem;
+  font-weight: 800;
+}
+
+.tech-table__head span,
+.tech-table__row span {
+  padding: 0.95rem 0.85rem;
+  border-right: 1px solid rgba(84, 101, 144, 0.08);
+}
+
+.tech-table__row {
+  align-items: center;
+  border-top: 1px solid rgba(84, 101, 144, 0.1);
+  color: #30405d;
+  background: #fff;
+}
+
+.primary-cell {
+  font-weight: 800;
+}
+
+.state-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 84px;
+  min-height: 2.2rem;
+  padding: 0 0.85rem;
+  border-radius: 999px;
+  background: #eef7ea;
+  color: #2f7f37;
+  font-weight: 800;
+}
+
+.state-pill--inactive {
+  background: #fff4df;
+  color: #b46a10;
+}
+
+.actions-cell {
+  display: flex;
+  gap: 0.65rem;
+  align-items: center;
+}
+
+.empty-state {
+  margin-top: 1rem;
+  padding: 1.2rem;
+  border-radius: 18px;
+  background: #f6f8fe;
+  color: #66718c;
+  text-align: center;
+}
+
+@media (max-width: 860px) {
+  .page-header,
+  .table-toolbar,
+  .summary-grid {
+    grid-template-columns: 1fr;
+    display: grid;
+  }
+}

--- a/src/app/pages/technicians/technicians-page.component.ts
+++ b/src/app/pages/technicians/technicians-page.component.ts
@@ -1,0 +1,25 @@
+import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TechnicianFormModalComponent } from '../../components/technician-form-modal.component';
+import { TechnicianStoreService } from '../../services/technician-store.service';
+
+@Component({
+  selector: 'app-technicians-page',
+  imports: [CommonModule, TechnicianFormModalComponent],
+  templateUrl: './technicians-page.component.html',
+  styleUrl: './technicians-page.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class TechniciansPageComponent {
+  protected readonly technicianStore = inject(TechnicianStoreService);
+
+  protected readonly technicians = computed(() => this.technicianStore.technicians());
+  protected readonly totals = computed(() => ({
+    total: this.technicianStore.technicians().length,
+    active: this.technicianStore.activeTechnicians().length
+  }));
+
+  constructor() {
+    this.technicianStore.ensureLoaded();
+  }
+}

--- a/src/app/pipe/state-color-pipe.ts
+++ b/src/app/pipe/state-color-pipe.ts
@@ -8,12 +8,14 @@ export class StateColorPipe implements PipeTransform {
   transform(state: string | null | undefined): string {
     if (!state) return 'badge-default';
 
+    console.log('StateColorPipe: transforming state', state);
+
     switch (state.toLowerCase()) {
       case 'disponible':
         return 'badge-primary';
       case 'en uso':
         return 'badge-secondary';
-      case 'mantenimiento':
+      case 'en mantenimiento':
         return 'badge-tertiary';
       default:
         return 'badge-default';

--- a/src/app/services/location-store.service.ts
+++ b/src/app/services/location-store.service.ts
@@ -1,0 +1,151 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { computed, inject, Injectable, signal } from '@angular/core';
+import { finalize } from 'rxjs';
+import { LocationPayload, ToolLocation } from '../models/location.model';
+import { ConfirmService } from './confirm.service';
+import { ToastService } from './toast.service';
+import { ToolApiService } from './tool-api.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LocationStoreService {
+  private readonly toolApi = inject(ToolApiService);
+  private readonly toastService = inject(ToastService);
+  private readonly confirmService = inject(ConfirmService);
+
+  readonly locations = signal<ToolLocation[]>([]);
+  readonly loading = signal(false);
+  readonly saving = signal(false);
+  readonly saveError = signal<string | null>(null);
+
+  private initialized = false;
+
+  readonly locationNames = computed(() => this.locations().map((location) => location.name));
+
+  ensureLoaded(): void {
+    if (this.initialized) {
+      return;
+    }
+
+    this.initialized = true;
+    this.loadLocations();
+  }
+
+  reload(): void {
+    this.loadLocations();
+  }
+
+  saveLocation(payload: LocationPayload, locationId?: string): Promise<ToolLocation> {
+    this.saveError.set(null);
+    this.saving.set(true);
+
+    const request$ = locationId
+      ? this.toolApi.updateLocation(locationId, payload)
+      : this.toolApi.createLocation(payload);
+
+    return new Promise((resolve, reject) => {
+      request$
+        .pipe(finalize(() => this.saving.set(false)))
+        .subscribe({
+          next: (location) => {
+            const nextLocations = locationId
+              ? this.locations().map((item) => item.id === location.id ? location : item)
+              : [...this.locations(), location];
+
+            this.locations.set(
+              [...nextLocations].sort((left, right) => left.name.localeCompare(right.name, 'es'))
+            );
+            this.toastService.show({
+              title: locationId ? 'Ubicacion actualizada' : 'Ubicacion creada',
+              message: `${location.name} se guardo correctamente.`,
+              tone: 'success'
+            });
+            resolve(location);
+          },
+          error: (error: unknown) => {
+            const message = this.extractErrorMessage(error);
+            this.saveError.set(message);
+            this.toastService.show({
+              title: 'No se pudo guardar la ubicacion',
+              message,
+              tone: 'error'
+            });
+            reject(error);
+          }
+        });
+    });
+  }
+
+  deleteLocation(location: ToolLocation): void {
+    this.confirmService.confirm({
+      title: 'Eliminar ubicacion',
+      message: `¿Deseas eliminar "${location.name}"? Las herramientas que ya la usen conservaran el texto, pero dejara de aparecer como opcion nueva.`,
+      confirmLabel: 'Eliminar',
+      tone: 'danger'
+    }).then((confirmed) => {
+      if (!confirmed) {
+        return;
+      }
+
+      this.toolApi.deleteLocation(location.id).subscribe({
+        next: () => {
+          this.locations.set(this.locations().filter((item) => item.id !== location.id));
+          this.toastService.show({
+            title: 'Ubicacion eliminada',
+            message: `${location.name} se elimino correctamente.`,
+            tone: 'success'
+          });
+        },
+        error: (error: unknown) => {
+          this.toastService.show({
+            title: 'No se pudo eliminar',
+            message: this.extractErrorMessage(error),
+            tone: 'error'
+          });
+        }
+      });
+    });
+  }
+
+  private loadLocations(): void {
+    this.loading.set(true);
+
+    this.toolApi.getLocations()
+      .pipe(finalize(() => this.loading.set(false)))
+      .subscribe({
+        next: (locations) => {
+          this.locations.set(
+            [...locations].sort((left, right) => left.name.localeCompare(right.name, 'es'))
+          );
+        },
+        error: (error: unknown) => {
+          this.toastService.show({
+            title: 'No se pudieron cargar las ubicaciones',
+            message: this.extractErrorMessage(error),
+            tone: 'error'
+          });
+        }
+      });
+  }
+
+  private extractErrorMessage(error: unknown): string {
+    if (error instanceof HttpErrorResponse) {
+      const responseError = error.error as { message?: string; errors?: string[] } | null;
+
+      if (Array.isArray(responseError?.errors) && responseError.errors.length > 0) {
+        return responseError.errors.join(' ');
+      }
+
+      if (typeof responseError?.message === 'string' && responseError.message.trim() !== '') {
+        return responseError.message;
+      }
+    }
+
+    if (error instanceof Error && error.message.trim() !== '') {
+      return error.message;
+    }
+
+    return 'Ha ocurrido un error inesperado.';
+  }
+}

--- a/src/app/services/technician-store.service.ts
+++ b/src/app/services/technician-store.service.ts
@@ -1,0 +1,172 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { computed, inject, Injectable, signal } from '@angular/core';
+import { finalize } from 'rxjs';
+import { Technician, TechnicianFormSubmission } from '../models/repair.model';
+import { ConfirmService } from './confirm.service';
+import { ToastService } from './toast.service';
+import { ToolApiService } from './tool-api.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TechnicianStoreService {
+  private readonly toolApi = inject(ToolApiService);
+  private readonly toastService = inject(ToastService);
+  private readonly confirmService = inject(ConfirmService);
+
+  readonly technicians = signal<Technician[]>([]);
+  readonly loading = signal(false);
+  readonly saving = signal(false);
+  readonly modalOpen = signal(false);
+  readonly editingTechnician = signal<Technician | null>(null);
+  readonly saveError = signal<string | null>(null);
+
+  private initialized = false;
+
+  readonly activeTechnicians = computed(() =>
+    this.technicians().filter((technician) => technician.active)
+  );
+
+  ensureLoaded(): void {
+    if (this.initialized) {
+      return;
+    }
+
+    this.initialized = true;
+    this.loadTechnicians();
+  }
+
+  reload(): void {
+    this.loadTechnicians();
+  }
+
+  openCreateModal(): void {
+    this.saveError.set(null);
+    this.editingTechnician.set(null);
+    this.modalOpen.set(true);
+  }
+
+  openEditModal(technician: Technician): void {
+    this.saveError.set(null);
+    this.editingTechnician.set(technician);
+    this.modalOpen.set(true);
+  }
+
+  closeModal(): void {
+    this.saveError.set(null);
+    this.editingTechnician.set(null);
+    this.modalOpen.set(false);
+  }
+
+  saveTechnician(submission: TechnicianFormSubmission): void {
+    this.saveError.set(null);
+    this.saving.set(true);
+
+    const currentEditing = this.editingTechnician();
+    const request$ = submission.mode === 'edit' && currentEditing
+      ? this.toolApi.updateTechnician(currentEditing.id, submission.payload)
+      : this.toolApi.createTechnician(submission.payload);
+
+    request$
+      .pipe(finalize(() => this.saving.set(false)))
+      .subscribe({
+        next: (technician) => {
+          const nextTechnicians = submission.mode === 'edit'
+            ? this.technicians().map((item) => item.id === technician.id ? technician : item)
+            : [...this.technicians(), technician];
+
+          this.technicians.set(
+            [...nextTechnicians].sort((left, right) => left.name.localeCompare(right.name, 'es'))
+          );
+          this.saveError.set(null);
+          this.toastService.show({
+            title: submission.mode === 'edit' ? 'Tecnico actualizado' : 'Tecnico creado',
+            message: `${technician.name} se guardo correctamente.`,
+            tone: 'success'
+          });
+          this.closeModal();
+        },
+        error: (error: unknown) => {
+          const message = this.extractErrorMessage(error);
+          this.saveError.set(message);
+          this.toastService.show({
+            title: 'No se pudo guardar el tecnico',
+            message,
+            tone: 'error'
+          });
+        }
+      });
+  }
+
+  deleteTechnician(technician: Technician): void {
+    this.confirmService.confirm({
+      title: 'Eliminar tecnico',
+      message: `¿Deseas eliminar a "${technician.name}"? Los historicos ya guardados conservaran su nombre, pero no podra volver a seleccionarse.`,
+      confirmLabel: 'Eliminar',
+      tone: 'danger'
+    }).then((confirmed) => {
+      if (!confirmed) {
+        return;
+      }
+
+      this.toolApi.deleteTechnician(technician.id).subscribe({
+        next: () => {
+          this.technicians.set(this.technicians().filter((item) => item.id !== technician.id));
+          this.toastService.show({
+            title: 'Tecnico eliminado',
+            message: `${technician.name} se elimino correctamente.`,
+            tone: 'success'
+          });
+        },
+        error: (error: unknown) => {
+          this.toastService.show({
+            title: 'No se pudo eliminar',
+            message: this.extractErrorMessage(error),
+            tone: 'error'
+          });
+        }
+      });
+    });
+  }
+
+  private loadTechnicians(): void {
+    this.loading.set(true);
+
+    this.toolApi.getTechnicians()
+      .pipe(finalize(() => this.loading.set(false)))
+      .subscribe({
+        next: (technicians) => {
+          this.technicians.set(
+            [...technicians].sort((left, right) => left.name.localeCompare(right.name, 'es'))
+          );
+        },
+        error: (error: unknown) => {
+          this.toastService.show({
+            title: 'No se pudieron cargar los tecnicos',
+            message: this.extractErrorMessage(error),
+            tone: 'error'
+          });
+        }
+      });
+  }
+
+  private extractErrorMessage(error: unknown): string {
+    if (error instanceof HttpErrorResponse) {
+      const responseError = error.error as { message?: string; errors?: string[] } | null;
+
+      if (Array.isArray(responseError?.errors) && responseError.errors.length > 0) {
+        return responseError.errors.join(' ');
+      }
+
+      if (typeof responseError?.message === 'string' && responseError.message.trim() !== '') {
+        return responseError.message;
+      }
+    }
+
+    if (error instanceof Error && error.message.trim() !== '') {
+      return error.message;
+    }
+
+    return 'Ha ocurrido un error inesperado.';
+  }
+}

--- a/src/app/services/tool-api.service.ts
+++ b/src/app/services/tool-api.service.ts
@@ -2,6 +2,14 @@ import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Tool, ToolListResponse, ToolPayload } from '../models/tool.model';
+import {
+  RepairPayload,
+  RepairRecord,
+  Technician,
+  TechnicianPayload
+} from '../models/repair.model';
+import { LocationPayload, ToolLocation } from '../models/location.model';
+import { ToolType, ToolTypePayload } from '../models/tool-type.model';
 import { environment } from '../../environments/environment';
 
 @Injectable({
@@ -10,6 +18,9 @@ import { environment } from '../../environments/environment';
 export class ToolApiService {
   private readonly http = inject(HttpClient);
   private readonly baseUrl = environment.apiUrl + '/api/tools';
+  private readonly techniciansUrl = environment.apiUrl + '/api/technicians';
+  private readonly locationsUrl = environment.apiUrl + '/api/locations';
+  private readonly toolTypesUrl = environment.apiUrl + '/api/tool-types';
 
   getTools(): Observable<Tool[] | ToolListResponse> {
     return this.http.get<Tool[] | ToolListResponse>(this.baseUrl);
@@ -44,5 +55,68 @@ export class ToolApiService {
   deleteImage(id: string): Observable<{ message: string; tool: Tool }> {
     return this.http.delete<{ message: string; tool: Tool }>(`${this.baseUrl}/${id}/image`);
   }
-}
 
+  getToolRepairs(toolId: string): Observable<RepairRecord[]> {
+    return this.http.get<RepairRecord[]>(`${this.baseUrl}/${toolId}/repairs`);
+  }
+
+  createToolRepair(toolId: string, payload: RepairPayload): Observable<RepairRecord> {
+    return this.http.post<RepairRecord>(`${this.baseUrl}/${toolId}/repairs`, payload);
+  }
+
+  updateToolRepair(toolId: string, repairId: string, payload: RepairPayload): Observable<RepairRecord> {
+    return this.http.put<RepairRecord>(`${this.baseUrl}/${toolId}/repairs/${repairId}`, payload);
+  }
+
+  deleteToolRepair(toolId: string, repairId: string): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/${toolId}/repairs/${repairId}`);
+  }
+
+  getTechnicians(): Observable<Technician[]> {
+    return this.http.get<Technician[]>(this.techniciansUrl);
+  }
+
+  createTechnician(payload: TechnicianPayload): Observable<Technician> {
+    return this.http.post<Technician>(this.techniciansUrl, payload);
+  }
+
+  updateTechnician(id: string, payload: TechnicianPayload): Observable<Technician> {
+    return this.http.put<Technician>(`${this.techniciansUrl}/${id}`, payload);
+  }
+
+  deleteTechnician(id: string): Observable<void> {
+    return this.http.delete<void>(`${this.techniciansUrl}/${id}`);
+  }
+
+  getLocations(): Observable<ToolLocation[]> {
+    return this.http.get<ToolLocation[]>(this.locationsUrl);
+  }
+
+  createLocation(payload: LocationPayload): Observable<ToolLocation> {
+    return this.http.post<ToolLocation>(this.locationsUrl, payload);
+  }
+
+  updateLocation(id: string, payload: LocationPayload): Observable<ToolLocation> {
+    return this.http.put<ToolLocation>(`${this.locationsUrl}/${id}`, payload);
+  }
+
+  deleteLocation(id: string): Observable<void> {
+    return this.http.delete<void>(`${this.locationsUrl}/${id}`);
+  }
+
+  getToolTypes(): Observable<ToolType[]> {
+    return this.http.get<ToolType[]>(this.toolTypesUrl);
+  }
+
+  createToolType(payload: ToolTypePayload): Observable<ToolType> {
+    return this.http.post<ToolType>(this.toolTypesUrl, payload);
+  }
+
+  updateToolType(id: string, payload: ToolTypePayload): Observable<ToolType> {
+    return this.http.put<ToolType>(`${this.toolTypesUrl}/${id}`, payload);
+  }
+
+  deleteToolType(id: string): Observable<void> {
+    return this.http.delete<void>(`${this.toolTypesUrl}/${id}`);
+  }
+}

--- a/src/app/services/tool-store.service.ts
+++ b/src/app/services/tool-store.service.ts
@@ -49,7 +49,9 @@ export class ToolStoreService {
         tool.category,
         tool.description,
         tool.material,
-        tool.state
+        tool.state,
+        tool.serialNumber,
+        tool.location
       ].join(' ').toLowerCase();
 
       return haystack.includes(search);
@@ -85,7 +87,7 @@ export class ToolStoreService {
       },
       {
         id: 'maintenance',
-        title: 'Mantenimiento',
+        title: 'En Mantenimiento',
         accent: '#f14e31',
         items: items.filter((tool) => this.resolveColumn(tool.state) === 'maintenance')
       }

--- a/src/app/services/tool-type-store.service.ts
+++ b/src/app/services/tool-type-store.service.ts
@@ -1,0 +1,147 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { computed, inject, Injectable, signal } from '@angular/core';
+import { finalize } from 'rxjs';
+import { ToolType, ToolTypePayload } from '../models/tool-type.model';
+import { ConfirmService } from './confirm.service';
+import { ToastService } from './toast.service';
+import { ToolApiService } from './tool-api.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ToolTypeStoreService {
+  private readonly toolApi = inject(ToolApiService);
+  private readonly toastService = inject(ToastService);
+  private readonly confirmService = inject(ConfirmService);
+
+  readonly toolTypes = signal<ToolType[]>([]);
+  readonly loading = signal(false);
+  readonly saving = signal(false);
+  readonly saveError = signal<string | null>(null);
+
+  private initialized = false;
+
+  readonly typeNames = computed(() => this.toolTypes().map((item) => item.name));
+
+  ensureLoaded(): void {
+    if (this.initialized) {
+      return;
+    }
+
+    this.initialized = true;
+    this.loadToolTypes();
+  }
+
+  saveToolType(payload: ToolTypePayload, toolTypeId?: string): Promise<ToolType> {
+    this.saveError.set(null);
+    this.saving.set(true);
+
+    const request$ = toolTypeId
+      ? this.toolApi.updateToolType(toolTypeId, payload)
+      : this.toolApi.createToolType(payload);
+
+    return new Promise((resolve, reject) => {
+      request$
+        .pipe(finalize(() => this.saving.set(false)))
+        .subscribe({
+          next: (toolType) => {
+            const nextToolTypes = toolTypeId
+              ? this.toolTypes().map((item) => item.id === toolType.id ? toolType : item)
+              : [...this.toolTypes(), toolType];
+
+            this.toolTypes.set(
+              [...nextToolTypes].sort((left, right) => left.name.localeCompare(right.name, 'es'))
+            );
+            this.toastService.show({
+              title: toolTypeId ? 'Tipo actualizado' : 'Tipo creado',
+              message: `${toolType.name} se guardo correctamente.`,
+              tone: 'success'
+            });
+            resolve(toolType);
+          },
+          error: (error: unknown) => {
+            const message = this.extractErrorMessage(error);
+            this.saveError.set(message);
+            this.toastService.show({
+              title: 'No se pudo guardar el tipo',
+              message,
+              tone: 'error'
+            });
+            reject(error);
+          }
+        });
+    });
+  }
+
+  deleteToolType(toolType: ToolType): void {
+    this.confirmService.confirm({
+      title: 'Eliminar tipo',
+      message: `¿Deseas eliminar "${toolType.name}"? Las herramientas que ya lo usen conservaran el texto, pero dejara de aparecer como opcion nueva.`,
+      confirmLabel: 'Eliminar',
+      tone: 'danger'
+    }).then((confirmed) => {
+      if (!confirmed) {
+        return;
+      }
+
+      this.toolApi.deleteToolType(toolType.id).subscribe({
+        next: () => {
+          this.toolTypes.set(this.toolTypes().filter((item) => item.id !== toolType.id));
+          this.toastService.show({
+            title: 'Tipo eliminado',
+            message: `${toolType.name} se elimino correctamente.`,
+            tone: 'success'
+          });
+        },
+        error: (error: unknown) => {
+          this.toastService.show({
+            title: 'No se pudo eliminar',
+            message: this.extractErrorMessage(error),
+            tone: 'error'
+          });
+        }
+      });
+    });
+  }
+
+  private loadToolTypes(): void {
+    this.loading.set(true);
+
+    this.toolApi.getToolTypes()
+      .pipe(finalize(() => this.loading.set(false)))
+      .subscribe({
+        next: (toolTypes) => {
+          this.toolTypes.set(
+            [...toolTypes].sort((left, right) => left.name.localeCompare(right.name, 'es'))
+          );
+        },
+        error: (error: unknown) => {
+          this.toastService.show({
+            title: 'No se pudieron cargar los tipos',
+            message: this.extractErrorMessage(error),
+            tone: 'error'
+          });
+        }
+      });
+  }
+
+  private extractErrorMessage(error: unknown): string {
+    if (error instanceof HttpErrorResponse) {
+      const responseError = error.error as { message?: string; errors?: string[] } | null;
+
+      if (Array.isArray(responseError?.errors) && responseError.errors.length > 0) {
+        return responseError.errors.join(' ');
+      }
+
+      if (typeof responseError?.message === 'string' && responseError.message.trim() !== '') {
+        return responseError.message;
+      }
+    }
+
+    if (error instanceof Error && error.message.trim() !== '') {
+      return error.message;
+    }
+
+    return 'Ha ocurrido un error inesperado.';
+  }
+}


### PR DESCRIPTION
I've created a new frontend page for tracking repairs with a structure very similar to your reference, reusing what already exists in the current frontend and preparing it to connect to the backend endpoints later.

The main components are located in:

- repairs-page.component.ts
- repairs-page.component.html
- repairs-page.component.scss
I also connected it to the navigation and the router in:

- app.routes.ts
- app-shell.component.html
The new page includes:

- a tool header reusing real data from the ToolStoreService
- a tool selector based on the current inventory
- an information block with name, brand, model, image, status, and local metadata
- a "Register New Repair" form
- a history for each tool with a table
- a PDF export of the history
- and quick editing of the selected tool reusing the existing modal