### PR TITLE
complete page redesign [major]

### DIFF
--- a/src/app/components/app-shell.component.html
+++ b/src/app/components/app-shell.component.html
@@ -92,7 +92,7 @@
         @if (showCreateAction()) {
         <button type="button" class="create-button" (click)="store.openCreateModal()">
           <span>＋</span>
-          Anadir Herramienta
+          Nueva herramienta
         </button>
         }
       </div>

--- a/src/app/components/app-shell.component.scss
+++ b/src/app/components/app-shell.component.scss
@@ -13,7 +13,7 @@
   inset: 0;
   z-index: 19;
   border: none;
-  background: rgba(19, 28, 49, 0.34);
+  background: rgba(35, 52, 90, 0.24);
   backdrop-filter: blur(4px);
   opacity: 0;
   animation: overlay-fade-in 0.26s ease forwards;
@@ -25,18 +25,20 @@
 
 .sidebar {
   position: fixed;
-  inset: 0 auto 0 0;
+  inset: 1rem auto 1rem 1rem;
   z-index: 20;
-  width: 280px;
+  width: 292px;
   display: grid;
   grid-template-rows: auto auto 1fr auto;
   gap: 1.5rem;
   padding: 1.4rem 1rem;
   background:
-    radial-gradient(circle at top left, rgba(119, 149, 255, 0.3), transparent 24%),
+    radial-gradient(circle at top left, rgba(246, 215, 104, 0.34), transparent 28%),
     linear-gradient(180deg, var(--sidebar-top) 0%, var(--sidebar-bottom) 100%);
-  color: #fff;
-  box-shadow: inset -1px 0 0 rgba(255, 255, 255, 0.08);
+  color: var(--text);
+  border: 3px solid var(--primary);
+  border-radius: 28px;
+  box-shadow: var(--shadow-lg);
   opacity: 0;
   transform: translateX(-100%) scale(0.985);
   transform-origin: left center;
@@ -50,27 +52,36 @@
 
 .brand {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 0.9rem;
-  padding: 0.25rem 0.4rem 0 0.35rem;
+  padding: 0.75rem 0.85rem;
   min-height: 48px;
+  min-width: 0;
+  border: 3px solid var(--primary);
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.68);
+  box-shadow: 4px 6px 0 rgba(35, 52, 90, 0.88);
 
   img {
-    width: 42px;
-    height: 42px;
+    width: 46px;
+    height: 46px;
   }
 
   h1 {
     margin: 0.2rem 0 0;
-    font-size: 1.7rem;
+    font-size: 1.5rem;
     line-height: 1.05;
     letter-spacing: -0.05em;
   }
 }
 
+.brand-copy {
+  min-width: 0;
+}
+
 .brand-kicker {
   margin: 0;
-  color: rgba(255, 255, 255, 0.68);
+  color: #66728e;
   font-size: 0.72rem;
   font-weight: 800;
   letter-spacing: 0.12em;
@@ -78,11 +89,19 @@
 }
 
 .brand-version {
-  margin: 0.3rem 0 0;
-  color: rgba(255, 255, 255, 0.72);
-  font-size: 0.78rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.7rem;
+  margin: 0.5rem 0 0;
+  padding: 0.16rem 0.62rem;
+  border: 2px solid rgba(35, 52, 90, 0.16);
+  border-radius: 999px;
+  background: #fffdf8;
+  color: #53627f;
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
 .nav {
@@ -96,10 +115,10 @@
   gap: 0.85rem;
   min-height: 3.25rem;
   padding: 0 1rem;
-  border: 1px solid transparent;
-  border-radius: 14px;
-  background: transparent;
-  color: rgba(255, 255, 255, 0.82);
+  border: 3px solid var(--primary);
+  border-radius: 18px;
+  background: #fffdf8;
+  color: var(--text);
   font-weight: 700;
   text-align: left;
   text-decoration: none;
@@ -107,30 +126,37 @@
   transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, transform 0.18s ease;
 
   &.active {
-    background: rgba(255, 255, 255, 0.95);
-    color: #2c3a55;
-    box-shadow: 0 14px 24px rgba(18, 26, 49, 0.22);
+    background: var(--accent-yellow);
+    box-shadow: 4px 6px 0 rgba(35, 52, 90, 0.9);
   }
 
   &:hover {
-    transform: translateX(2px);
+    transform: translate(-1px, -1px);
+    box-shadow: 4px 6px 0 rgba(35, 52, 90, 0.9);
   }
 }
 
 .nav-icon {
-  display: inline-grid;
+  display: inline-flex;
   place-items: center;
-  width: 1.4rem;
-  font-size: 1.15rem;
-  flex: 0 0 1.4rem;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border: 2px solid rgba(35, 52, 90, 0.14);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.86);
+  font-size: 1.05rem;
+  flex: 0 0 2rem;
 }
 
 .sidebar-card {
   align-self: start;
   padding: 1rem;
   border-radius: 18px;
-  background: rgba(255, 255, 255, 0.09);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--accent-mint);
+  border: 3px solid var(--primary);
+  box-shadow: 4px 6px 0 rgba(35, 52, 90, 0.88);
 
   p {
     margin: 0 0 0.95rem;
@@ -139,23 +165,32 @@
 
   dl {
     display: grid;
-    gap: 0.85rem;
+    gap: 0.75rem;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     margin: 0;
   }
 
   div {
-    display: flex;
-    justify-content: space-between;
-    gap: 1rem;
+    display: grid;
+    gap: 0.15rem;
+    padding: 0.7rem 0.8rem;
+    border: 2px solid rgba(35, 52, 90, 0.14);
+    border-radius: 16px;
+    background: rgba(255, 255, 255, 0.72);
   }
 
   dt {
-    color: rgba(255, 255, 255, 0.68);
+    color: #4f5c79;
+    font-size: 0.8rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
   }
 
   dd {
     margin: 0;
-    font-weight: 800;
+    font-size: 1.18rem;
+    font-weight: 900;
   }
 }
 
@@ -167,7 +202,7 @@
 .line {
   display: block;
   height: 1px;
-  background: rgba(255, 255, 255, 0.16);
+  background: rgba(35, 52, 90, 0.18);
 }
 
 .footer-item {
@@ -179,6 +214,10 @@
   align-content: start;
   gap: 1.2rem;
   padding: 1.5rem 1.4rem 2rem;
+}
+
+.sidebar.open ~ .workspace {
+  padding-left: 332px;
 }
 
 .topbar {
@@ -201,18 +240,18 @@
   justify-content: center;
   min-width: 3rem;
   min-height: 3rem;
-  border: none;
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.92);
-  box-shadow: 0 10px 22px rgba(42, 57, 92, 0.08);
-  color: #2a3550;
+  border: 3px solid var(--primary);
+  border-radius: 18px;
+  background: #fffdf8;
+  box-shadow: 4px 6px 0 rgba(35, 52, 90, 0.9);
+  color: var(--primary);
   font-size: 1.2rem;
   font-weight: 900;
   transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease, color 0.18s ease;
 
   &:hover {
-    transform: translateY(-1px);
-    box-shadow: 0 14px 28px rgba(42, 57, 92, 0.12);
+    transform: translate(-1px, -1px);
+    box-shadow: 5px 7px 0 rgba(35, 52, 90, 0.92);
   }
 
   &::after {
@@ -240,9 +279,9 @@
   }
 
   &.open {
-    background: linear-gradient(135deg, var(--primary), var(--primary-strong));
-    color: #fff;
-    box-shadow: 0 16px 30px rgba(67, 111, 232, 0.24);
+    background: var(--accent-yellow);
+    color: var(--primary);
+    box-shadow: 4px 6px 0 rgba(35, 52, 90, 0.9);
     transform: rotate(90deg);
   }
 
@@ -257,12 +296,17 @@
   gap: 0.7rem;
   min-height: 3rem;
   padding: 0 1.2rem;
-  border: none;
-  border-radius: 12px;
-  background: linear-gradient(135deg, var(--primary), var(--primary-strong));
-  color: #fff;
+  border: 3px solid var(--primary);
+  border-radius: 18px;
+  background: var(--accent-yellow);
+  color: var(--primary);
   font-weight: 800;
-  box-shadow: 0 16px 30px rgba(67, 111, 232, 0.25);
+  box-shadow: 4px 6px 0 rgba(35, 52, 90, 0.9);
+
+  span {
+    font-size: 1.1rem;
+    line-height: 1;
+  }
 }
 
 .topbar-tools {
@@ -278,10 +322,10 @@
   min-width: min(420px, 48vw);
   min-height: 3rem;
   padding: 0 1rem;
-  border-radius: 14px;
-  border: 1px solid rgba(78, 94, 135, 0.14);
-  background: rgba(255, 255, 255, 0.9);
-  box-shadow: 0 10px 22px rgba(42, 57, 92, 0.06);
+  border-radius: 20px;
+  border: 3px solid var(--primary);
+  background: #fffdf8;
+  box-shadow: 4px 6px 0 rgba(35, 52, 90, 0.9);
 
   span {
     color: #56627f;
@@ -307,11 +351,11 @@
   justify-content: center;
   min-width: 2.9rem;
   min-height: 2.9rem;
-  border: none;
+  border: 3px solid var(--primary);
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.9);
-  box-shadow: 0 10px 22px rgba(42, 57, 92, 0.08);
-  color: #2a3550;
+  background: #fffdf8;
+  box-shadow: 4px 6px 0 rgba(35, 52, 90, 0.9);
+  color: var(--primary);
 }
 
 .avatar-button {
@@ -325,8 +369,8 @@
   width: 2.2rem;
   height: 2.2rem;
   border-radius: 999px;
-  background: linear-gradient(135deg, #ffda6f, #f5a353);
-  color: #253046;
+  background: var(--accent-mint);
+  color: var(--primary);
   font-weight: 900;
 }
 
@@ -337,15 +381,21 @@
 
 .hero-strip {
   display: flex;
-  align-items: end;
+  align-items: stretch;
   justify-content: space-between;
   gap: 1rem;
-  padding: 1rem 0 0.25rem;
-  border-bottom: 1px solid rgba(74, 92, 138, 0.12);
+  padding: 1.2rem 1.25rem;
+  border: 3px solid var(--primary);
+  border-radius: 26px;
+  background:
+    radial-gradient(circle at top left, rgba(246, 215, 104, 0.2), transparent 24%),
+    radial-gradient(circle at bottom right, rgba(142, 223, 192, 0.18), transparent 22%),
+    var(--panel);
+  box-shadow: var(--shadow-md);
 
   .eyebrow {
     margin: 0;
-    color: #4d77ef;
+    color: #5b6884;
     text-transform: uppercase;
     letter-spacing: 0.16em;
     font-size: 0.72rem;
@@ -354,7 +404,7 @@
 
   h2 {
     margin: 0.2rem 0 0;
-    font-size: 2rem;
+    font-size: clamp(1.55rem, 2.2vw, 2.1rem);
     letter-spacing: -0.05em;
   }
 }
@@ -363,6 +413,8 @@
   display: grid;
   gap: 0.6rem;
   justify-items: end;
+  min-width: 0;
+  align-content: end;
 }
 
 .page-description {
@@ -370,16 +422,19 @@
   margin: 0;
   color: #62708a;
   text-align: right;
+  line-height: 1.55;
 }
 
 .banner {
   max-width: 460px;
   margin: 0;
-  padding: 0.85rem 1rem;
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.76);
-  color: #5b647d;
-  box-shadow: 0 12px 26px rgba(42, 57, 92, 0.05);
+  padding: 0.95rem 1.05rem;
+  border-radius: 18px;
+  border: 3px solid var(--primary);
+  background: var(--accent-cream);
+  color: #3f4f70;
+  font-weight: 700;
+  box-shadow: 4px 6px 0 rgba(35, 52, 90, 0.88);
 }
 
 @keyframes overlay-fade-in {
@@ -396,6 +451,16 @@
 }
 
 @media (max-width: 760px) {
+  .sidebar {
+    inset: 0 auto 0 0;
+    width: min(292px, calc(100vw - 0.85rem));
+    border-radius: 0 24px 24px 0;
+  }
+
+  .sidebar.open ~ .workspace {
+    padding-left: 1rem;
+  }
+
   .workspace {
     padding: 1rem 0.9rem 1.4rem;
   }
@@ -407,13 +472,50 @@
     align-items: stretch;
   }
 
+  .topbar-start {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+
+  .create-button {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .topbar-tools {
+    width: 100%;
+  }
+
   .search-box {
     min-width: 100%;
+  }
+
+  .sidebar-card dl {
+    grid-template-columns: 1fr;
   }
 
   .hero-copy,
   .page-description {
     justify-items: start;
     text-align: left;
+  }
+
+  .banner {
+    max-width: 100%;
+  }
+}
+
+@media (max-width: 520px) {
+  .brand {
+    padding: 0.7rem;
+  }
+
+  .brand h1 {
+    font-size: 1.3rem;
+  }
+
+  .nav-item {
+    min-height: 3rem;
+    padding: 0 0.85rem;
   }
 }

--- a/src/app/components/confirm-dialog.component.scss
+++ b/src/app/components/confirm-dialog.component.scss
@@ -8,7 +8,7 @@
 .confirm-backdrop {
   position: absolute;
   inset: 0;
-  background: rgba(18, 27, 49, 0.48);
+  background: rgba(35, 52, 90, 0.28);
   backdrop-filter: blur(8px);
   pointer-events: auto;
 }
@@ -19,11 +19,15 @@
   left: 50%;
   width: min(460px, calc(100vw - 2rem));
   padding: 1.5rem;
-  border-radius: 24px;
-  background: rgba(255, 255, 255, 0.98);
-  box-shadow: 0 28px 70px rgba(18, 27, 49, 0.24);
+  border-radius: 28px;
+  border: 3px solid var(--primary);
+  background: #fffdf8;
+  box-shadow: 8px 10px 0 rgba(35, 52, 90, 0.9);
   transform: translate(-50%, -50%);
   pointer-events: auto;
+  background:
+    radial-gradient(circle at top right, rgba(246, 215, 104, 0.18), transparent 28%),
+    #fffdf8;
 
   h3 {
     margin: 0.35rem 0 0;
@@ -35,11 +39,11 @@
 
 .eyebrow {
   margin: 0;
-  color: #4d77ef;
+  color: rgba(35, 52, 90, 0.72);
   text-transform: uppercase;
   letter-spacing: 0.14em;
   font-size: 0.72rem;
-  font-weight: 800;
+  font-weight: 900;
 }
 
 .message {
@@ -59,22 +63,29 @@
 .primary {
   min-height: 2.9rem;
   padding: 0 1rem;
-  border: none;
-  border-radius: 14px;
-  font-weight: 800;
+  border: 3px solid var(--primary);
+  border-radius: 18px;
+  font-weight: 900;
+  box-shadow: 4px 6px 0 rgba(35, 52, 90, 0.88);
+  transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease;
 }
 
 .secondary {
-  background: #eef1fb;
+  background: #fffdf8;
   color: #33405f;
 }
 
 .primary {
-  background: linear-gradient(135deg, #4677f6, #2d60e9);
-  color: #fff;
+  background: var(--accent-yellow);
+  color: var(--primary);
 }
 
 .danger {
-  background: linear-gradient(135deg, #db645d, #c4453f);
+  background: #ffd9d4;
 }
 
+.secondary:hover,
+.primary:hover {
+  transform: translate(-1px, -1px);
+  box-shadow: 5px 7px 0 rgba(35, 52, 90, 0.92);
+}

--- a/src/app/components/toast-stack.component.scss
+++ b/src/app/components/toast-stack.component.scss
@@ -17,10 +17,10 @@
   gap: 0.8rem;
   width: min(360px, calc(100vw - 2rem));
   padding: 0.95rem 1rem;
-  border-radius: 18px;
-  border: 1px solid rgba(87, 102, 139, 0.14);
-  background: rgba(255, 255, 255, 0.96);
-  box-shadow: 0 20px 44px rgba(31, 47, 86, 0.16);
+  border-radius: 22px;
+  border: 3px solid var(--primary);
+  background: rgba(255, 253, 248, 0.98);
+  box-shadow: 6px 8px 0 rgba(35, 52, 90, 0.9);
   pointer-events: auto;
 
   h4 {
@@ -44,23 +44,22 @@
   }
 
   &.success {
-    border-left: 5px solid #4f9b43;
+    background: #e4f5ec;
   }
 
   &.info {
-    border-left: 5px solid #4677f6;
+    background: #eef3ff;
   }
 
   &.warning {
-    border-left: 5px solid #e18a11;
+    background: #fff6d9;
   }
 
   &.error {
-    border-left: 5px solid #d95b57;
+    background: #ffe3de;
   }
 }
 
 .toast-copy {
   flex: 1;
 }
-

--- a/src/app/components/tool-card.component.html
+++ b/src/app/components/tool-card.component.html
@@ -1,4 +1,4 @@
-<article class="tool-card">
+<article class="tool-card" [attr.data-column]="column()">
   <header class="card-header">
     <div>
       <h3>{{ tool().name }}</h3>
@@ -6,11 +6,13 @@
         <span class="meta-pill">Serie: {{ tool().serialNumber }}</span>
         <span class="meta-pill meta-pill--soft">Ubicacion: {{ tool().location }}</span>
       </div>
-      <p [class.expanded]="expanded()" class="textlong">{{ tool().description }}</p>
+      <div class="description-shell">
+        <p [class.expanded]="expanded()" class="textlong">{{ tool().description }}</p>
+      </div>
       @if (tool().description.length > 100) {
-      <span (click)="changeLongDescription()" class="toggle">
+      <button type="button" (click)="changeLongDescription()" class="toggle">
         {{ expanded() ? ' ver menos' : '... ver más' }}
-      </span>
+      </button>
       }
     </div>
 

--- a/src/app/components/tool-card.component.scss
+++ b/src/app/components/tool-card.component.scss
@@ -6,10 +6,22 @@
   display: grid;
   gap: 1rem;
   padding: 1rem;
-  border-radius: 18px;
-  background: linear-gradient(180deg, #ffffff 0%, #fbfcff 100%);
-  border: 1px solid rgba(84, 103, 151, 0.14);
-  box-shadow: 0 12px 32px rgba(43, 57, 96, 0.09);
+  border-radius: 24px;
+  background: #fffdf8;
+  border: 3px solid var(--primary);
+  box-shadow: 5px 7px 0 rgba(35, 52, 90, 0.9);
+}
+
+.tool-card[data-column='available'] {
+  background: #fff9da;
+}
+
+.tool-card[data-column='active'] {
+  background: #d4f2e5;
+}
+
+.tool-card[data-column='maintenance'] {
+  background: #fffdf8;
 }
 
 .card-header {
@@ -18,17 +30,17 @@
   justify-content: space-between;
   gap: 1rem;
   padding-bottom: 0.85rem;
-  border-bottom: 1px solid rgba(74, 92, 138, 0.14);
+  border-bottom: 2px solid rgba(35, 52, 90, 0.12);
 
   h3 {
     margin: 0;
-    font-size: 1.3rem;
-    font-weight: 800;
-    letter-spacing: -0.03em;
+    font-size: clamp(1.12rem, 1.4vw, 1.28rem);
+    font-weight: 900;
+    letter-spacing: -0.04em;
   }
 
   p {
-    margin: 0.35rem 0 0;
+    margin: 0;
     color: var(--muted);
     line-height: 1.45;
     font-size: 0.92rem;
@@ -48,15 +60,24 @@
   min-height: 1.8rem;
   padding: 0.2rem 0.7rem;
   border-radius: 999px;
-  background: #edf2ff;
+  background: #fffdf8;
   color: #24459d;
+  border: 2px solid rgba(35, 52, 90, 0.18);
   font-size: 0.78rem;
   font-weight: 800;
 }
 
 .meta-pill--soft {
-  background: #f1f5fb;
+  background: rgba(142, 223, 192, 0.18);
   color: #596684;
+}
+
+.description-shell {
+  margin-top: 0.7rem;
+  padding: 0.72rem 0.8rem;
+  border: 2px dashed rgba(35, 52, 90, 0.14);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.44);
 }
 
 .ghost-icon {
@@ -78,7 +99,7 @@
 .textlong {
   overflow: hidden;
   display: -webkit-box;
-  -webkit-line-clamp: 3; // número de líneas visibles
+  -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
 
   &.expanded {
@@ -87,11 +108,16 @@
 }
 
 .toggle {
-  align-items: end;
-  color: rgb(141, 141, 143);
+  display: inline-flex;
+  justify-self: end;
+  margin-top: 0.45rem;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: rgb(104, 112, 133);
   cursor: pointer;
   font-weight: 800;
-  font-size: small;
+  font-size: 0.78rem;
   text-align: right;
 }
 
@@ -106,11 +132,12 @@
   display: grid;
   place-items: center;
   min-height: 126px;
-  border-radius: 16px;
-  border: 1px solid rgba(71, 72, 73, 0.14);
-  // background:
-  // radial-gradient(circle at top, rgba(255, 190, 90, 0.16), transparent 55%),
-  // linear-gradient(180deg, #f8f9ff 0%, #eef3ff 100%);
+  border-radius: 20px;
+  border: 3px solid rgba(35, 52, 90, 0.18);
+  background:
+    radial-gradient(circle at top, rgba(246, 215, 104, 0.18), transparent 52%),
+    rgba(255, 255, 255, 0.84);
+  box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.45);
 
   img {
     padding: 0.2rem;
@@ -122,26 +149,31 @@
 
 .details {
   display: grid;
-  gap: 0.45rem;
+  gap: 0.55rem;
   margin: 0;
 
   .detail-row {
     display: grid;
     grid-template-columns: 92px 1fr;
     gap: 0.8rem;
+    padding: 0.45rem 0.55rem;
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.56);
   }
 
   dt {
     color: #6e7891;
-    font-size: 0.9rem;
+    font-size: 0.86rem;
     font-weight: 900;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
   }
 
   dd {
     margin: 0;
     color: #243047;
-    font-size: 0.8rem;
-    font-weight: 500;
+    font-size: 0.84rem;
+    font-weight: 700;
   }
 }
 
@@ -163,71 +195,70 @@
   padding: 0.35rem 0.8rem;
   border-radius: 999px;
   font-size: 0.8rem;
-  font-weight: 800;
+  font-weight: 900;
+  border: 2px solid rgba(35, 52, 90, 0.16);
+  box-shadow: 2px 3px 0 rgba(35, 52, 90, 0.18);
 }
 
 .badge-primary {
   background: #edf7ea;
   color: #3f8635;
-  // border: thin solid #3f8635;
 }
 
 .badge-secondary {
   background: #fbecd1;
   color: #e0a41a;
-  // border: thin solid #e0a41a;
 }
 
 .badge-tertiary {
   background: #f3dada;
   color: #b7311f;
-  // border: thin solid #b7311f;
 }
 
 .badge-default {
   background: #eef0fb;
   color: #5f6787;
-  // border: thin solid #5f6787;
 }
 
 .actions {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 0.55rem;
+  min-width: 0;
 }
 
 .action-button {
   min-height: 2.5rem;
-  border-radius: 10px;
-  border: 1px solid rgba(82, 98, 139, 0.16);
-  background: #fff;
+  border-radius: 16px;
+  border: 3px solid var(--primary);
+  background: #fffdf8;
   color: #283247;
   font-weight: 700;
-  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
-  font-size: clamp(0.8rem, 3vw, 0.8rem);
-
+  transition: transform 0.2s ease, background 0.2s ease;
+  font-size: clamp(0.78rem, 2vw, 0.84rem);
+  box-shadow: 3px 4px 0 rgba(35, 52, 90, 0.88);
+  min-width: 0;
 
   &:hover {
-    transform: translateY(-1px);
-    border-color: rgba(70, 119, 246, 0.34);
-    box-shadow: 0 10px 20px rgba(63, 88, 156, 0.12);
+    transform: translate(-1px, -1px);
+    background: rgba(246, 215, 104, 0.76);
   }
 }
 
 .image-link {
   min-height: 2.5rem;
-  border-radius: 10px;
-  border: 1px solid rgba(82, 98, 139, 0.16);
-  background: #fff;
+  border-radius: 16px;
+  border: 3px solid var(--primary);
+  background: #fffdf8;
   color: #283247;
   font-weight: 700;
-  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  transition: transform 0.2s ease, background 0.2s ease;
   font-size: clamp(0.8rem, 3vw, 0.8rem);
+  box-shadow: 3px 4px 0 rgba(35, 52, 90, 0.88);
 
   &:hover {
-    transform: translateY(-2px);
-    border-color: rgba(226, 57, 42, 0.34);
-    box-shadow: 0 10px 20px rgba(63, 88, 156, 0.12);
+    transform: translate(-1px, -1px);
+    background: #ffe0db;
   }
 }
 

--- a/src/app/components/tool-form-modal.component.scss
+++ b/src/app/components/tool-form-modal.component.scss
@@ -8,7 +8,7 @@
 .modal-backdrop {
   position: absolute;
   inset: 0;
-  background: rgba(28, 40, 73, 0.48);
+  background: rgba(35, 52, 90, 0.34);
   backdrop-filter: blur(10px);
   pointer-events: auto;
 }
@@ -21,9 +21,10 @@
   max-height: calc(100vh - 3rem);
   overflow: auto;
   padding: 1.6rem;
-  border-radius: 26px;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(247, 249, 255, 0.96));
-  box-shadow: 0 36px 90px rgba(16, 27, 56, 0.28);
+  border-radius: 30px;
+  border: 3px solid var(--primary);
+  background: linear-gradient(180deg, #fffdf8, #f9f3e9);
+  box-shadow: 8px 10px 0 rgba(35, 52, 90, 0.9);
   transform: translate(-50%, -50%);
   pointer-events: auto;
 }
@@ -37,11 +38,11 @@
 
   .eyebrow {
     margin: 0;
-    color: #4d77ef;
+    color: rgba(35, 52, 90, 0.72);
     text-transform: uppercase;
     letter-spacing: 0.18em;
     font-size: 0.72rem;
-    font-weight: 800;
+    font-weight: 900;
   }
 
   h2 {
@@ -56,10 +57,18 @@
   width: 2.6rem;
   height: 2.6rem;
   border-radius: 999px;
-  border: 1px solid rgba(83, 99, 137, 0.14);
-  background: #fff;
+  border: 3px solid var(--primary);
+  background: #fffdf8;
   color: #354056;
   font-size: 1.5rem;
+  box-shadow: var(--shadow-sm);
+  transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease;
+}
+
+.close-button:hover {
+  transform: translate(-1px, -1px);
+  box-shadow: 5px 6px 0 rgba(35, 52, 90, 0.92);
+  background: var(--accent-yellow);
 }
 
 .modal-form {
@@ -71,9 +80,10 @@
   display: grid;
   gap: 0.35rem;
   padding: 0.95rem 1rem;
-  border-radius: 16px;
-  border: 1px solid rgba(214, 95, 95, 0.22);
-  background: #fff4f4;
+  border-radius: 18px;
+  border: 3px solid rgba(179, 66, 53, 0.2);
+  background: #fff1ef;
+  box-shadow: 3px 4px 0 rgba(179, 66, 53, 0.08);
   color: #9f2f2f;
 
   strong {
@@ -119,7 +129,7 @@ label,
 .field-error {
   color: #b43333;
   font-size: 0.82rem;
-  font-weight: 700;
+  font-weight: 800;
 }
 
 input,
@@ -128,16 +138,16 @@ select {
   width: 100%;
   min-height: 3rem;
   padding: 0.8rem 1rem;
-  border-radius: 14px;
-  border: 1px solid rgba(92, 106, 144, 0.14);
-  background: rgba(248, 250, 255, 0.96);
+  border-radius: 18px;
+  border: 3px solid rgba(35, 52, 90, 0.2);
+  background: rgba(255, 253, 248, 0.96);
   color: #22304a;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 
   &:focus {
     outline: none;
-    border-color: rgba(70, 119, 246, 0.45);
-    box-shadow: 0 0 0 4px rgba(70, 119, 246, 0.12);
+    border-color: var(--primary);
+    box-shadow: 4px 5px 0 rgba(35, 52, 90, 0.88);
   }
 }
 
@@ -152,9 +162,9 @@ textarea {
   justify-content: space-between;
   gap: 1rem;
   padding: 1rem 1.1rem;
-  border-radius: 18px;
-  background: linear-gradient(135deg, rgba(68, 119, 246, 0.08), rgba(255, 188, 72, 0.08));
-  border: 1px dashed rgba(69, 117, 241, 0.28);
+  border-radius: 22px;
+  background: linear-gradient(135deg, rgba(246, 215, 104, 0.28), rgba(142, 223, 192, 0.24));
+  border: 3px dashed rgba(35, 52, 90, 0.24);
 
   p {
     margin: 0.25rem 0 0;
@@ -176,16 +186,23 @@ textarea {
   min-height: 2.9rem;
   padding: 0 1rem;
   border-radius: 999px;
-  background: #fff;
-  border: 1px solid rgba(69, 117, 241, 0.26);
-  color: #355fda;
-  font-weight: 800;
+  background: #fffdf8;
+  border: 3px solid var(--primary);
+  color: var(--primary);
+  font-weight: 900;
+  box-shadow: var(--shadow-sm);
+  transition: transform 160ms ease, box-shadow 160ms ease;
 
   input {
     position: absolute;
     inset: 0;
     opacity: 0;
   }
+}
+
+.file-picker:hover {
+  transform: translate(-1px, -1px);
+  box-shadow: 5px 6px 0 rgba(35, 52, 90, 0.92);
 }
 
 .helper {
@@ -214,19 +231,27 @@ textarea {
   min-width: 176px;
   min-height: 3rem;
   padding: 0 1.2rem;
-  border-radius: 14px;
+  border-radius: 18px;
   font-weight: 800;
-  border: none;
+  border: 3px solid var(--primary);
+  box-shadow: 4px 6px 0 rgba(35, 52, 90, 0.88);
+  transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease;
 }
 
 .primary {
-  background: linear-gradient(135deg, #4677f6, #2d60e9);
-  color: #fff;
+  background: var(--accent-yellow);
+  color: var(--primary);
 }
 
 .secondary {
-  background: #eef1fb;
+  background: #fffdf8;
   color: #33405f;
+}
+
+.primary:hover,
+.secondary:hover {
+  transform: translate(-1px, -1px);
+  box-shadow: 5px 7px 0 rgba(35, 52, 90, 0.92);
 }
 
 @media (max-width: 900px) {

--- a/src/app/pages/categories/categories-page.component.scss
+++ b/src/app/pages/categories/categories-page.component.scss
@@ -1,13 +1,14 @@
 .categories-page {
   display: grid;
-  gap: 1rem;
+  gap: 1.2rem;
 }
 
 .categories-toolbar,
 .categories-grid {
-  border-radius: 22px;
-  background: rgba(255, 255, 255, 0.84);
-  box-shadow: 0 16px 34px rgba(36, 50, 79, 0.09);
+  border: 3px solid var(--primary);
+  border-radius: 28px;
+  background: var(--panel);
+  box-shadow: var(--shadow-lg);
 }
 
 .categories-toolbar {
@@ -15,19 +16,22 @@
   align-items: start;
   justify-content: space-between;
   gap: 1rem;
-  padding: 1.1rem;
+  padding: 1.3rem 1.4rem;
 }
 
 .categories-grid {
-  columns: 2 24rem;
-  column-gap: 1rem;
-  padding: 1rem;
+  columns: 2 26rem;
+  column-gap: 1.2rem;
+  padding: 1.2rem;
+  background:
+    radial-gradient(circle at top right, rgba(142, 223, 192, 0.12), transparent 28%),
+    var(--panel);
 }
 
 h2 {
-  margin: 0.22rem 0 0;
-  font-size: 1.45rem;
-  letter-spacing: -0.04em;
+  margin: 0.24rem 0 0;
+  font-size: clamp(1.6rem, 2vw, 2rem);
+  letter-spacing: -0.05em;
 }
 
 .toolbar-controls {
@@ -39,29 +43,32 @@ h2 {
 
 .toolbar-field {
   display: grid;
-  gap: 0.4rem;
+  gap: 0.45rem;
 
   span {
-    color: #66718c;
-    font-size: 0.88rem;
-    font-weight: 700;
+    color: rgba(35, 52, 90, 0.75);
+    font-size: 0.82rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
   }
 
   select {
-    min-height: 44px;
-    min-width: 160px;
-    padding: 0 0.95rem;
-    border: 1px solid #d9e0f1;
-    border-radius: 14px;
-    background: #f8faff;
-    color: #25324a;
+    min-height: 50px;
+    min-width: 170px;
+    padding: 0 1rem;
+    border: 3px solid rgba(35, 52, 90, 0.2);
+    border-radius: 18px;
+    background: #fffdf8;
+    color: var(--primary);
     font: inherit;
+    box-shadow: 3px 4px 0 rgba(35, 52, 90, 0.82);
     outline: none;
   }
 
   select:focus {
-    border-color: #4d77ef;
-    box-shadow: 0 0 0 4px rgba(77, 119, 239, 0.14);
+    border-color: var(--primary);
+    box-shadow: 4px 5px 0 rgba(35, 52, 90, 0.88);
   }
 }
 
@@ -69,11 +76,12 @@ h2 {
 .empty-card {
   display: inline-block;
   width: 100%;
-  margin: 0 0 1rem;
-  padding: 1.1rem;
-  border-radius: 22px;
-  background: rgba(255, 255, 255, 0.84);
-  box-shadow: 0 16px 34px rgba(36, 50, 79, 0.09);
+  margin: 0 0 1.1rem;
+  padding: 1.2rem;
+  border: 3px solid var(--primary);
+  border-radius: 28px;
+  background: linear-gradient(180deg, #fffdf8 0%, #fff7e5 100%);
+  box-shadow: var(--shadow-md);
   break-inside: avoid;
 }
 
@@ -83,65 +91,71 @@ h2 {
   justify-content: space-between;
   gap: 1rem;
   inline-size: 100%;
-  padding: 0;
+  padding: 0.35rem 0.5rem;
   border: 0;
+  border-radius: 22px;
   background: transparent;
   text-align: left;
   cursor: pointer;
-  border-radius: 18px;
-  transition: background-color 180ms ease, transform 180ms ease, padding 180ms ease;
+  transition: background-color 180ms ease, transform 180ms ease;
 }
 
 .card-top:hover {
-  background: rgba(77, 119, 239, 0.06);
+  background: rgba(246, 215, 104, 0.24);
 }
 
 .card-top--expanded {
-  padding: 0.2rem 0.35rem;
-  background: rgba(77, 119, 239, 0.08);
+  background: rgba(142, 223, 192, 0.24);
 }
 
 .card-top__meta {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.85rem;
+  min-width: 0;
 }
 
 .eyebrow {
   margin: 0;
-  color: #4d77ef;
+  color: rgba(35, 52, 90, 0.72);
   text-transform: uppercase;
   letter-spacing: 0.14em;
   font-size: 0.72rem;
-  font-weight: 800;
+  font-weight: 900;
 }
 
 h3 {
-  margin: 0.22rem 0 0;
-  font-size: 1.45rem;
-  letter-spacing: -0.04em;
+  margin: 0.25rem 0 0;
+  font-size: clamp(1.35rem, 1.9vw, 1.75rem);
+  letter-spacing: -0.05em;
 }
 
 .count {
-  padding: 0.45rem 0.85rem;
+  padding: 0.5rem 0.92rem;
+  border: 3px solid var(--primary);
   border-radius: 999px;
-  background: #eef1fb;
-  color: #50607c;
-  font-weight: 800;
+  background: #fff;
+  color: var(--primary);
+  font-weight: 900;
+  box-shadow: 3px 4px 0 rgba(35, 52, 90, 0.84);
+  white-space: nowrap;
 }
 
 .chevron {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  inline-size: 34px;
-  block-size: 34px;
+  inline-size: 40px;
+  block-size: 40px;
+  border: 3px solid var(--primary);
   border-radius: 999px;
-  background: #f3f6fd;
-  color: #5c6b87;
-  font-size: 1.2rem;
-  font-weight: 800;
+  background: var(--accent-yellow);
+  color: var(--primary);
+  font-size: 1.15rem;
+  font-weight: 900;
+  box-shadow: 3px 4px 0 rgba(35, 52, 90, 0.84);
   transition: transform 180ms ease;
+  flex: none;
 }
 
 .chevron--collapsed {
@@ -152,46 +166,51 @@ h3 {
   display: grid;
   grid-template-rows: 1fr;
   opacity: 1;
-  transition: grid-template-rows 220ms ease, opacity 180ms ease, margin-top 220ms ease;
+  transition: grid-template-rows 240ms ease, opacity 180ms ease, margin-top 220ms ease;
 }
 
 .category-table-shell--collapsed {
   grid-template-rows: 0fr;
-  opacity: 0.7;
+  opacity: 0.78;
 }
 
 .category-table {
   margin-top: 1rem;
-  border: 1px solid rgba(84, 101, 144, 0.12);
-  border-radius: 18px;
+  border: 3px solid var(--primary);
+  border-radius: 22px;
   overflow: hidden;
-  background: #fbfcff;
+  background: #fffdf8;
+  box-shadow: 4px 6px 0 rgba(35, 52, 90, 0.84);
 }
 
 .category-table-shell--collapsed .category-table {
-  margin-top: 0.55rem;
+  margin-top: 0.6rem;
 }
 
 .category-table__head,
 .category-table__row {
   display: grid;
-  grid-template-columns: 80px minmax(180px, 1.2fr) minmax(100px, 0.8fr) minmax(100px, 0.8fr) auto;
+  grid-template-columns: 84px minmax(180px, 1.2fr) minmax(120px, 0.8fr) minmax(120px, 0.8fr) auto;
   gap: 0.9rem;
   align-items: center;
-  padding: 0.9rem 1rem;
+  padding: 0.95rem 1rem;
 }
 
 .category-table__head {
-  background: #f3f6fd;
-  color: #65718c;
+  background: var(--accent-yellow);
+  color: var(--primary);
   font-size: 0.8rem;
-  font-weight: 800;
+  font-weight: 900;
   text-transform: uppercase;
   letter-spacing: 0.08em;
 }
 
 .category-table__row {
-  border-top: 1px solid rgba(84, 101, 144, 0.1);
+  border-top: 2px solid rgba(35, 52, 90, 0.12);
+}
+
+.category-table__row:nth-child(even) {
+  background: rgba(142, 223, 192, 0.08);
 }
 
 .tool-image {
@@ -199,12 +218,14 @@ h3 {
   justify-content: center;
 
   img {
-    width: 56px;
-    height: 56px;
+    width: 60px;
+    height: 60px;
     object-fit: contain;
-    border-radius: 12px;
-    background: linear-gradient(180deg, #f8f9ff 0%, #eef3ff 100%);
+    border: 3px solid var(--primary);
+    border-radius: 16px;
+    background: #fff;
     padding: 0.35rem;
+    box-shadow: 3px 4px 0 rgba(35, 52, 90, 0.82);
   }
 }
 
@@ -217,76 +238,92 @@ h3 {
   }
 
   strong {
-    color: #25324a;
+    color: var(--primary);
+    font-size: 1rem;
   }
 
   span {
-    margin-top: 0.22rem;
-    color: #68738d;
+    margin-top: 0.24rem;
+    color: rgba(35, 52, 90, 0.72);
     font-size: 0.92rem;
   }
 }
 
 .tool-meta {
-  color: #5f6d88;
+  color: rgba(35, 52, 90, 0.76);
   font-size: 0.92rem;
 }
 
 .tool-state {
   justify-self: end;
-  padding: 0.45rem 0.8rem;
+  padding: 0.45rem 0.85rem;
+  border: 3px solid var(--primary);
   border-radius: 999px;
-  font-weight: 800;
-  font-size: 0.7rem;
+  font-weight: 900;
+  font-size: 0.72rem;
   white-space: nowrap;
+  box-shadow: 2px 3px 0 rgba(35, 52, 90, 0.78);
 }
 
 .tool-state--available {
-  background: #eef7ea;
-  color: #2f7f37;
+  background: #dff4dd;
+  color: #2a6f3e;
 }
 
 .tool-state--active {
-  background: #fff4df;
-  color: #b46a10;
+  background: #ffe9b5;
+  color: #a76100;
 }
 
 .tool-state--maintenance {
-  background: #fff1f1;
-  color: #c23a3a;
+  background: #ffd8d2;
+  color: #b34235;
 }
 
 .category-table__empty {
   padding: 1rem;
-  color: #66718c;
   text-align: center;
+  color: rgba(35, 52, 90, 0.7);
 }
 
-.empty-card {
-  text-align: center;
-  color: #66718c;
-}
-
-@media (max-width: 1100px) {
-  .categories-grid {
-    columns: 1;
-  }
-}
-
-@media (max-width: 760px) {
-
-  .categories-toolbar,
-  .toolbar-controls {
+@media (max-width: 920px) {
+  .categories-toolbar {
     display: grid;
+  }
+
+  .toolbar-controls,
+  .toolbar-field {
+    width: 100%;
+  }
+
+  .toolbar-field select {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .categories-grid {
+    columns: 1 100%;
+  }
+
+  .category-table {
+    overflow-x: auto;
   }
 
   .category-table__head,
   .category-table__row {
-    grid-template-columns: 1fr;
+    min-width: 740px;
+  }
+}
+
+@media (max-width: 560px) {
+  .categories-toolbar,
+  .categories-grid,
+  .category-card,
+  .empty-card {
+    padding: 1rem;
   }
 
-  .tool-image,
-  .tool-state {
-    justify-self: start;
+  .card-top {
+    padding-inline: 0;
   }
 }

--- a/src/app/pages/dashboard/dashboard-page.component.html
+++ b/src/app/pages/dashboard/dashboard-page.component.html
@@ -6,7 +6,7 @@
 } @else {
   <section class="board">
     @for (column of store.columns(); track column.id) {
-      <div class="column">
+      <div class="column" [class.column--available]="column.id === 'available'" [class.column--active]="column.id === 'active'" [class.column--maintenance]="column.id === 'maintenance'">
         <header class="column-header">
           <div class="column-title">
             <span class="column-dot" [style.background]="column.accent"></span>

--- a/src/app/pages/dashboard/dashboard-page.component.scss
+++ b/src/app/pages/dashboard/dashboard-page.component.scss
@@ -3,8 +3,10 @@
   place-items: center;
   gap: 1rem;
   min-height: 360px;
+  padding: 1.5rem;
   border-radius: 26px;
-  background: rgba(255, 255, 255, 0.78);
+  border: 3px solid var(--primary);
+  background: var(--panel);
   box-shadow: var(--shadow-md);
 
   p {
@@ -35,6 +37,22 @@
   gap: 1rem;
   min-height: 100%;
   align-content: start;
+  padding: 1rem;
+  border-radius: 26px;
+  border: 3px solid var(--primary);
+  box-shadow: var(--shadow-md);
+}
+
+.column--available {
+  background: linear-gradient(180deg, #fff2b7 0%, #fff9da 100%);
+}
+
+.column--active {
+  background: linear-gradient(180deg, #a9e5cb 0%, #dff7ec 100%);
+}
+
+.column--maintenance {
+  background: linear-gradient(180deg, #fffdf8 0%, #f6f0e6 100%);
 }
 
 .column-header {
@@ -42,7 +60,8 @@
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
-  padding: 0 0.1rem;
+  padding: 0.15rem 0.1rem 0.7rem;
+  border-bottom: 2px dashed rgba(35, 52, 90, 0.16);
 }
 
 .column-title {
@@ -52,15 +71,16 @@
 
   h3 {
     margin: 0;
-    font-size: 1.05rem;
-    font-weight: 800;
+    font-size: 1.08rem;
+    font-weight: 900;
   }
 }
 
 .column-dot {
-  width: 0.95rem;
-  height: 0.95rem;
-  border-radius: 4px;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 6px;
+  border: 2px solid rgba(35, 52, 90, 0.2);
 }
 
 .column-count {
@@ -70,9 +90,11 @@
   min-height: 2rem;
   padding: 0 0.5rem;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.78);
+  border: 3px solid var(--primary);
+  background: #fffdf8;
   color: #53607c;
-  font-weight: 800;
+  font-weight: 900;
+  box-shadow: 3px 4px 0 rgba(35, 52, 90, 0.82);
 }
 
 .column-content {
@@ -83,7 +105,9 @@
 .empty-card {
   padding: 1.2rem;
   border-radius: 18px;
-  background: rgba(255, 255, 255, 0.72);
+  border: 3px solid var(--primary);
+  background: rgba(255, 253, 248, 0.85);
+  box-shadow: 4px 6px 0 rgba(35, 52, 90, 0.85);
   color: #66718c;
   text-align: center;
 }

--- a/src/app/pages/inventory/inventory-page.component.html
+++ b/src/app/pages/inventory/inventory-page.component.html
@@ -8,7 +8,7 @@
           <p class="eyebrow">Vista operativa</p>
           <h3>Inventario completo</h3>
         </div>
-        <span class="count">{{ rows().length }} items</span>
+        <span class="count">{{ rows().length }} herramientas</span>
       </header>
 
       <div class="table">
@@ -27,20 +27,24 @@
             [class.table-row--available]="getStateTone(tool.state) === 'available'"
             [class.table-row--active]="getStateTone(tool.state) === 'active'"
             [class.table-row--maintenance]="getStateTone(tool.state) === 'maintenance'">
-            <div class="tool-cell">
+            <div class="tool-cell" data-label="Herramienta">
               <img [src]="store.getImage(tool)" [alt]="tool.name">
               <div>
                 <strong>{{ tool.name }}</strong>
                 <p>{{ tool.type }}</p>
+                <div class="tool-tags">
+                  <span>{{ tool.serialNumber }}</span>
+                  <span>{{ tool.location }}</span>
+                </div>
               </div>
             </div>
-            <span>{{ tool.category }}</span>
-            <span class="status" [class.status--available]="getStateTone(tool.state) === 'available'" [class.status--active]="getStateTone(tool.state) === 'active'" [class.status--maintenance]="getStateTone(tool.state) === 'maintenance'">
+            <span data-label="Categoria">{{ tool.category }}</span>
+            <span data-label="Estado" class="status" [class.status--available]="getStateTone(tool.state) === 'available'" [class.status--active]="getStateTone(tool.state) === 'active'" [class.status--maintenance]="getStateTone(tool.state) === 'maintenance'">
               {{ tool.state }}
             </span>
-            <span>{{ tool.material }}</span>
-            <span>{{ tool.long }} cm</span>
-            <div class="row-actions">
+            <span data-label="Material">{{ tool.material }}</span>
+            <span data-label="Longitud">{{ tool.long }} cm</span>
+            <div class="row-actions" data-label="Acciones">
               <button type="button" (click)="store.openEditModal(tool)">Editar</button>
               <div class="state-menu" (click)="$event.stopPropagation()">
                 <button
@@ -100,7 +104,7 @@
 
       <article class="mini-panel">
         <p class="eyebrow">Modo</p>
-        <h3>{{ store.useDemoData() ? 'Demo local' : 'API conectada' }}</h3>
+        <h3>{{ store.useDemoData() ? 'Modo demostracion' : 'Sincronizacion activa' }}</h3>
         <p class="muted">
           {{ store.useDemoData() ? 'Estas navegando con datos de ejemplo.' : 'Las acciones se sincronizan con el backend.' }}
         </p>

--- a/src/app/pages/inventory/inventory-page.component.scss
+++ b/src/app/pages/inventory/inventory-page.component.scss
@@ -8,8 +8,9 @@
 .inventory-table,
 .mini-panel {
   border-radius: 24px;
-  background: rgba(255, 255, 255, 0.82);
-  box-shadow: 0 16px 34px rgba(36, 50, 79, 0.09);
+  border: 3px solid var(--primary);
+  background: var(--panel);
+  box-shadow: var(--shadow-md);
 }
 
 .panel {
@@ -18,6 +19,9 @@
 
 .inventory-table {
   padding: 1rem;
+  background:
+    radial-gradient(circle at top right, rgba(246, 215, 104, 0.16), transparent 28%),
+    var(--panel);
 }
 
 .table-header {
@@ -29,30 +33,37 @@
 
   .eyebrow {
     margin: 0;
-    color: #4d77ef;
+    color: rgba(35, 52, 90, 0.72);
     text-transform: uppercase;
     letter-spacing: 0.14em;
     font-size: 0.72rem;
-    font-weight: 800;
+    font-weight: 900;
   }
 
   h3 {
     margin: 0.2rem 0 0;
-    font-size: 1.5rem;
-    letter-spacing: -0.04em;
+    font-size: clamp(1.35rem, 2vw, 1.7rem);
+    letter-spacing: -0.05em;
   }
 }
 
 .count {
   padding: 0.45rem 0.85rem;
   border-radius: 999px;
-  background: #eef1fb;
+  border: 3px solid var(--primary);
+  background: #fffdf8;
   color: #50607c;
-  font-weight: 800;
+  font-weight: 900;
+  box-shadow: 3px 4px 0 rgba(35, 52, 90, 0.82);
 }
 
 .table {
   display: grid;
+  border: 3px solid var(--primary);
+  border-radius: 22px;
+  overflow: hidden;
+  background: #fffdf8;
+  box-shadow: 4px 6px 0 rgba(35, 52, 90, 0.84);
 }
 
 .table-row {
@@ -61,9 +72,10 @@
   grid-template-columns: 2fr 1fr 1fr 1fr 0.8fr 1.2fr;
   gap: 1rem;
   align-items: center;
-  padding: 0.95rem 0.35rem;
-  border-top: 1px solid rgba(85, 100, 135, 0.1);
+  padding: 1rem 0.7rem 1rem 1rem;
+  border-top: 2px solid rgba(85, 100, 135, 0.12);
   color: #30405d;
+  background: #fff;
 }
 
 .table-row::before {
@@ -88,39 +100,76 @@
 }
 
 .table-head {
-  color: #65718c;
+  color: var(--primary);
   font-size: 0.84rem;
-  font-weight: 800;
+  font-weight: 900;
   text-transform: uppercase;
   letter-spacing: 0.08em;
+  background: var(--accent-mint);
+}
+
+.table-row:not(.table-head):nth-child(odd) {
+  background: rgba(246, 215, 104, 0.08);
 }
 
 .tool-cell {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 0.85rem;
 
   img {
     width: 52px;
     height: 52px;
     object-fit: contain;
-    border-radius: 12px;
-    background: linear-gradient(180deg, #f8f9ff 0%, #eef3ff 100%);
+    border-radius: 16px;
+    border: 2px solid rgba(35, 52, 90, 0.16);
+    background: #fffdf8;
     padding: 0.35rem;
   }
 
   strong {
     display: block;
+    font-size: 0.98rem;
+    font-weight: 900;
   }
 
   p {
     margin: 0.2rem 0 0;
     color: #68738d;
+    font-weight: 700;
+  }
+}
+
+.tool-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.45rem;
+
+  span {
+    display: inline-flex;
+    align-items: center;
+    min-height: 1.65rem;
+    padding: 0.15rem 0.6rem;
+    border: 2px solid rgba(35, 52, 90, 0.14);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.72);
+    color: #586682;
+    font-size: 0.74rem;
+    font-weight: 800;
   }
 }
 
 .status {
-  font-weight: 800;
+  display: inline-flex;
+  justify-self: start;
+  align-items: center;
+  min-height: 2.1rem;
+  padding: 0.3rem 0.75rem;
+  border: 3px solid var(--primary);
+  border-radius: 999px;
+  font-weight: 900;
+  box-shadow: 2px 3px 0 rgba(35, 52, 90, 0.2);
 }
 
 .status--available {
@@ -142,14 +191,15 @@
   align-items: center;
 
   button {
-    width: 100%;
+    min-width: 106px;
     min-height: 2.2rem;
     padding: 0 0.8rem;
-    border-radius: 10px;
-    border: 1px solid rgba(84, 101, 144, 0.16);
-    background: #fff;
+    border-radius: 14px;
+    border: 3px solid var(--primary);
+    background: #fffdf8;
     font-weight: 700;
     text-align: center;
+    box-shadow: 3px 4px 0 rgba(35, 52, 90, 0.88);
   }
 }
 
@@ -160,6 +210,7 @@
 .state-trigger {
   min-width: 150px;
   text-align: left;
+  font-weight: 900;
 }
 
 .state-trigger--available {
@@ -189,10 +240,10 @@
   display: grid;
   gap: 0.35rem;
   padding: 0.45rem;
-  border: 1px solid rgba(84, 101, 144, 0.16);
+  border: 3px solid var(--primary);
   border-radius: 14px;
-  background: #fff;
-  box-shadow: 0 16px 34px rgba(36, 50, 79, 0.14);
+  background: #fffdf8;
+  box-shadow: var(--shadow-md);
 }
 
 .state-option {
@@ -219,20 +270,21 @@
 
 .mini-panel {
   padding: 1.1rem;
+  background: linear-gradient(180deg, #fffdf8 0%, #fff7e7 100%);
 
   .eyebrow {
     margin: 0;
-    color: #4d77ef;
+    color: rgba(35, 52, 90, 0.72);
     text-transform: uppercase;
     letter-spacing: 0.14em;
     font-size: 0.72rem;
-    font-weight: 800;
+    font-weight: 900;
   }
 
   h3 {
     margin: 0.2rem 0 0.7rem;
-    font-size: 1.35rem;
-    letter-spacing: -0.04em;
+    font-size: clamp(1.2rem, 1.8vw, 1.45rem);
+    letter-spacing: -0.05em;
   }
 }
 
@@ -245,8 +297,10 @@
     justify-content: space-between;
     align-items: center;
     padding: 0.8rem 0.9rem;
-    border-radius: 16px;
-    background: linear-gradient(135deg, rgba(71, 119, 246, 0.08), rgba(255, 190, 90, 0.08));
+    border-radius: 18px;
+    border: 3px solid rgba(35, 52, 90, 0.14);
+    background: linear-gradient(135deg, rgba(246, 215, 104, 0.24), rgba(142, 223, 192, 0.22));
+    box-shadow: 3px 4px 0 rgba(35, 52, 90, 0.16);
   }
 }
 
@@ -268,11 +322,74 @@
 }
 
 @media (max-width: 860px) {
+  .inventory-table {
+    padding: 0.9rem;
+  }
+
+  .table {
+    gap: 0.8rem;
+    border: none;
+    background: transparent;
+    box-shadow: none;
+  }
+
   .table-row {
     grid-template-columns: 1fr;
+    gap: 0.6rem;
+    padding: 1rem 0.95rem 1rem 1.1rem;
+    border: 3px solid var(--primary);
+    border-radius: 22px;
+    box-shadow: 4px 6px 0 rgba(35, 52, 90, 0.84);
   }
 
   .table-head {
     display: none;
+  }
+
+  .table-row > [data-label] {
+    display: grid;
+    gap: 0.32rem;
+  }
+
+  .table-row > [data-label]::before {
+    content: attr(data-label);
+    color: rgba(35, 52, 90, 0.72);
+    font-size: 0.72rem;
+    font-weight: 900;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .tool-cell {
+    display: grid;
+  }
+
+  .row-actions {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 560px) {
+  .table-header {
+    display: grid;
+  }
+
+  .count {
+    justify-self: start;
+  }
+
+  .row-actions button,
+  .state-trigger {
+    width: 100%;
+  }
+
+  .state-menu {
+    width: 100%;
+  }
+
+  .state-menu__panel {
+    right: 0;
+    left: 0;
+    min-width: 0;
   }
 }

--- a/src/app/pages/repairs/repairs-page.component.scss
+++ b/src/app/pages/repairs/repairs-page.component.scss
@@ -1,15 +1,16 @@
 .repairs-page {
   display: grid;
-  gap: 1rem;
+  gap: 1.2rem;
 }
 
 .repairs-header,
 .section-card,
 .empty-page {
-  padding: 1.2rem;
-  border-radius: 24px;
-  background: rgba(255, 255, 255, 0.84);
-  box-shadow: 0 16px 34px rgba(36, 50, 79, 0.09);
+  padding: 1.3rem;
+  border: 3px solid var(--primary);
+  border-radius: 28px;
+  background: var(--panel);
+  box-shadow: var(--shadow-lg);
 }
 
 .repairs-header {
@@ -17,34 +18,38 @@
   justify-content: space-between;
   align-items: end;
   gap: 1rem;
+  background:
+    radial-gradient(circle at top right, rgba(246, 215, 104, 0.18), transparent 30%),
+    var(--panel);
 }
 
 .eyebrow {
   margin: 0;
-  color: #4d77ef;
+  color: rgba(35, 52, 90, 0.72);
   text-transform: uppercase;
   letter-spacing: 0.14em;
   font-size: 0.72rem;
-  font-weight: 800;
+  font-weight: 900;
 }
 
 h2,
 h3 {
   margin: 0.25rem 0 0;
-  letter-spacing: -0.04em;
+  letter-spacing: -0.05em;
 }
 
 h2 {
-  font-size: 2rem;
+  font-size: clamp(1.9rem, 3vw, 2.5rem);
 }
 
 h3 {
-  font-size: 1.35rem;
+  font-size: clamp(1.3rem, 2vw, 1.6rem);
 }
 
 .intro {
-  margin: 0.65rem 0 0;
-  color: #63708b;
+  margin: 0.68rem 0 0;
+  color: rgba(35, 52, 90, 0.72);
+  max-width: 58rem;
 }
 
 .tool-selector,
@@ -52,38 +57,50 @@ label,
 .status-field,
 .image-field {
   display: grid;
-  gap: 0.45rem;
+  gap: 0.48rem;
 
   span {
-    color: #556178;
-    font-size: 0.86rem;
-    font-weight: 800;
+    color: rgba(35, 52, 90, 0.78);
+    font-size: 0.84rem;
+    font-weight: 900;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
   }
+}
+
+.tool-selector {
+  max-width: 320px;
 }
 
 input,
 textarea,
 select {
   width: 100%;
-  min-height: 3rem;
-  padding: 0.8rem 1rem;
-  border-radius: 14px;
-  border: 1px solid rgba(92, 106, 144, 0.14);
-  background: rgba(248, 250, 255, 0.96);
-  color: #22304a;
+  min-height: 3.2rem;
+  padding: 0.82rem 1rem;
+  border: 3px solid rgba(35, 52, 90, 0.2);
+  border-radius: 18px;
+  background: #fffdf8;
+  color: var(--primary);
   font: inherit;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 3px 4px 0 rgba(35, 52, 90, 0.82);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 
   &:focus {
     outline: none;
-    border-color: rgba(70, 119, 246, 0.45);
-    box-shadow: 0 0 0 4px rgba(70, 119, 246, 0.12);
+    border-color: var(--primary);
+    box-shadow: 4px 5px 0 rgba(35, 52, 90, 0.88);
   }
+}
+
+input[readonly] {
+  background: linear-gradient(180deg, #fffdf8 0%, #f7f0e2 100%);
+  color: rgba(35, 52, 90, 0.82);
 }
 
 textarea {
   resize: vertical;
-  min-height: 7rem;
+  min-height: 7.4rem;
 }
 
 .section-title {
@@ -97,10 +114,12 @@ textarea {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2.2rem;
-  height: 2.2rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  border: 3px solid var(--primary);
   border-radius: 999px;
-  background: #eef3ff;
+  background: var(--accent-yellow);
+  box-shadow: 3px 4px 0 rgba(35, 52, 90, 0.84);
   font-size: 1.1rem;
 }
 
@@ -122,44 +141,59 @@ textarea {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
+.info-grid > label,
+.info-grid > .status-field,
+.info-grid > .image-field,
+.form-grid > label {
+  padding: 0.9rem;
+  border: 3px solid rgba(35, 52, 90, 0.12);
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.62);
+  box-shadow: 3px 4px 0 rgba(35, 52, 90, 0.14);
+}
+
 .state-pill {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 3rem;
+  min-height: 3.2rem;
   padding: 0 1rem;
-  border-radius: 14px;
-  font-weight: 800;
+  border: 3px solid var(--primary);
+  border-radius: 18px;
+  font-weight: 900;
+  box-shadow: 3px 4px 0 rgba(35, 52, 90, 0.82);
 }
 
 .state-pill--available {
-  background: #eef7ea;
-  color: #2f7f37;
+  background: #dff4dd;
+  color: #2a6f3e;
 }
 
 .state-pill--active {
-  background: #fff4df;
-  color: #b46a10;
+  background: #ffe9b5;
+  color: #a76100;
 }
 
 .state-pill--maintenance {
-  background: #fff1f1;
-  color: #c23a3a;
+  background: #ffd8d2;
+  color: #b34235;
 }
 
 .image-card {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.85rem;
+  flex-wrap: wrap;
 
   img {
-    width: 102px;
-    height: 102px;
+    width: 108px;
+    height: 108px;
     object-fit: contain;
-    border-radius: 16px;
-    border: 1px solid rgba(92, 106, 144, 0.14);
+    border: 3px solid var(--primary);
+    border-radius: 20px;
     background: #fff;
-    padding: 0.4rem;
+    padding: 0.45rem;
+    box-shadow: 4px 6px 0 rgba(35, 52, 90, 0.84);
   }
 }
 
@@ -167,22 +201,34 @@ textarea {
 .primary,
 .secondary {
   min-height: 3rem;
-  padding: 0 1.1rem;
-  border-radius: 14px;
-  font-weight: 800;
+  padding: 0 1.15rem;
+  border: 3px solid var(--primary);
+  border-radius: 18px;
+  font-weight: 900;
   font: inherit;
+  box-shadow: 4px 6px 0 rgba(35, 52, 90, 0.88);
 }
 
-.image-edit {
-  border: 1px solid rgba(92, 106, 144, 0.14);
-  background: #fff;
-  color: #33405f;
+.image-edit,
+.secondary {
+  background: #fffdf8;
+  color: var(--primary);
+}
+
+.primary {
+  background: var(--accent-yellow);
+  color: var(--primary);
 }
 
 .field-error {
-  color: #b43333;
+  color: #b34235;
   font-size: 0.82rem;
-  font-weight: 700;
+  font-weight: 800;
+}
+
+.repair-form {
+  display: grid;
+  gap: 1rem;
 }
 
 .form-actions,
@@ -198,24 +244,17 @@ textarea {
   margin-top: 1rem;
 }
 
-.primary {
-  border: none;
-  background: linear-gradient(135deg, #1745a7, #0f3690);
-  color: #fff;
-}
-
-.secondary {
-  border: 1px solid rgba(92, 106, 144, 0.14);
-  background: #fff;
-  color: #33405f;
+.export-button {
+  white-space: nowrap;
 }
 
 .history-table {
   margin-top: 1rem;
-  border: 1px solid rgba(84, 101, 144, 0.12);
-  border-radius: 18px;
+  border: 3px solid var(--primary);
+  border-radius: 22px;
   overflow: hidden;
-  background: #fbfcff;
+  background: #fffdf8;
+  box-shadow: 4px 6px 0 rgba(35, 52, 90, 0.84);
 }
 
 .history-table__head,
@@ -226,44 +265,60 @@ textarea {
 }
 
 .history-table__head {
-  background: linear-gradient(180deg, #14356f 0%, #0d2a5a 100%);
-  color: #fff;
+  background: var(--accent-mint);
+  color: var(--primary);
   font-size: 0.8rem;
-  font-weight: 800;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
 }
 
 .history-table__head span,
 .history-table__row span {
   padding: 0.95rem 0.85rem;
-  border-right: 1px solid rgba(84, 101, 144, 0.08);
+  border-right: 2px solid rgba(35, 52, 90, 0.08);
 }
 
 .history-table__row {
   align-items: stretch;
-  border-top: 1px solid rgba(84, 101, 144, 0.1);
-  color: #30405d;
+  border-top: 2px solid rgba(35, 52, 90, 0.1);
+  color: rgba(35, 52, 90, 0.9);
   background: #fff;
 }
 
+.history-table__row:nth-child(even) {
+  background: rgba(246, 215, 104, 0.1);
+}
+
 .history-status {
-  color: #2f7f37;
-  font-weight: 800;
+  align-self: center;
+  justify-self: start;
+  display: inline-flex;
+  align-items: center;
+  min-height: 2rem;
+  padding: 0.3rem 0.75rem;
+  border: 3px solid var(--primary);
+  border-radius: 999px;
+  background: #dff4dd;
+  color: #2a6f3e;
+  font-weight: 900;
+  box-shadow: 2px 3px 0 rgba(35, 52, 90, 0.18);
 }
 
 .history-table__empty {
   padding: 1rem;
   text-align: center;
-  color: #66718c;
+  color: rgba(35, 52, 90, 0.7);
 }
 
 .history-footnote {
   margin: 1rem 0 0;
-  color: #66718c;
+  color: rgba(35, 52, 90, 0.7);
 }
 
 .empty-page {
   text-align: center;
-  color: #66718c;
+  color: rgba(35, 52, 90, 0.72);
 }
 
 @media (max-width: 1180px) {
@@ -294,5 +349,33 @@ textarea {
   .info-grid,
   .four-columns {
     grid-template-columns: 1fr;
+  }
+
+  .tool-selector {
+    max-width: none;
+  }
+}
+
+@media (max-width: 560px) {
+  .repairs-header,
+  .section-card,
+  .empty-page {
+    padding: 1rem;
+  }
+
+  .section-title {
+    align-items: start;
+  }
+
+  .image-edit,
+  .primary,
+  .secondary,
+  .export-button {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .history-footnote {
+    text-align: center;
   }
 }

--- a/src/app/pages/reports/reports-page.component.html
+++ b/src/app/pages/reports/reports-page.component.html
@@ -114,19 +114,19 @@
   </article>
 
   <article class="metrics-grid">
-    <div class="metric-card">
+    <div class="metric-card metric-card--total">
       <span>Total herramientas</span>
       <strong>{{ reportMetrics().totalTools }}</strong>
     </div>
-    <div class="metric-card">
+    <div class="metric-card metric-card--available">
       <span>Disponibilidad</span>
       <strong>{{ reportMetrics().availableRate }}%</strong>
     </div>
-    <div class="metric-card">
+    <div class="metric-card metric-card--active">
       <span>En uso</span>
       <strong>{{ reportMetrics().activeRate }}%</strong>
     </div>
-    <div class="metric-card">
+    <div class="metric-card metric-card--length">
       <span>Promedio longitud</span>
       <strong>{{ reportMetrics().averageLong }} cm</strong>
     </div>
@@ -296,7 +296,7 @@
           <em>{{ entry.ratio }}%</em>
         </div>
       } @empty {
-        <p class="empty">Sin datos.</p>
+        <p class="empty">Sin datos disponibles.</p>
       }
     </div>
   </article>

--- a/src/app/pages/reports/reports-page.component.scss
+++ b/src/app/pages/reports/reports-page.component.scss
@@ -1,6 +1,6 @@
 .reports-layout {
   display: grid;
-  gap: 1rem;
+  gap: 1.2rem;
 }
 
 .metrics-grid {
@@ -15,10 +15,17 @@
 .empty-report-state,
 .insights-card,
 .report-summary-card {
-  padding: 1.1rem;
-  border-radius: 22px;
-  background: rgba(255, 255, 255, 0.84);
-  box-shadow: 0 16px 34px rgba(36, 50, 79, 0.09);
+  padding: 1.2rem;
+  border: 3px solid var(--primary);
+  border-radius: 28px;
+  background: var(--panel);
+  box-shadow: var(--shadow-lg);
+}
+
+.filters-card {
+  background:
+    radial-gradient(circle at top right, rgba(246, 215, 104, 0.16), transparent 30%),
+    var(--panel);
 }
 
 .filters-header {
@@ -32,6 +39,7 @@
   display: flex;
   align-items: center;
   gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
 .filters-grid {
@@ -44,7 +52,7 @@
 .export-config {
   margin-top: 1rem;
   padding-top: 1rem;
-  border-top: 1px solid #e4e9f4;
+  border-top: 2px dashed rgba(35, 52, 90, 0.18);
 }
 
 .export-config__header,
@@ -74,18 +82,19 @@
   display: flex;
   align-items: center;
   gap: 0.7rem;
-  min-height: 54px;
+  min-height: 58px;
   padding: 0.85rem 0.95rem;
-  border: 1px solid #dbe3f3;
-  border-radius: 16px;
-  background: #f8faff;
-  color: #25324a;
-  font-weight: 700;
+  border: 3px solid rgba(35, 52, 90, 0.2);
+  border-radius: 18px;
+  background: #fffdf8;
+  color: var(--primary);
+  font-weight: 800;
+  box-shadow: 3px 4px 0 rgba(35, 52, 90, 0.82);
 
   input {
     inline-size: 18px;
     block-size: 18px;
-    accent-color: #4d77ef;
+    accent-color: var(--primary);
     margin: 0;
   }
 
@@ -94,63 +103,67 @@
   }
 }
 
+.export-check:hover {
+  transform: translate(-1px, -1px);
+  box-shadow: 4px 5px 0 rgba(35, 52, 90, 0.88);
+}
+
 .filter-field {
   display: grid;
   gap: 0.45rem;
 
   span {
-    color: #66718c;
-    font-size: 0.88rem;
-    font-weight: 700;
+    color: rgba(35, 52, 90, 0.76);
+    font-size: 0.82rem;
+    font-weight: 900;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
   }
 
   select {
-    min-height: 46px;
-    border: 1px solid #d9e0f1;
-    border-radius: 14px;
-    padding: 0 0.95rem;
-    background: #f8faff;
-    color: #25324a;
+    min-height: 50px;
+    border: 3px solid rgba(35, 52, 90, 0.2);
+    border-radius: 18px;
+    padding: 0 1rem;
+    background: #fffdf8;
+    color: var(--primary);
     font: inherit;
     outline: none;
-    transition: border-color 160ms ease, box-shadow 160ms ease, background 160ms ease;
+    box-shadow: 3px 4px 0 rgba(35, 52, 90, 0.82);
+    transition: border-color 160ms ease, box-shadow 160ms ease;
   }
 
   select:focus {
-    border-color: #4d77ef;
-    box-shadow: 0 0 0 4px rgba(77, 119, 239, 0.14);
-    background: #fff;
+    border-color: var(--primary);
+    box-shadow: 4px 5px 0 rgba(35, 52, 90, 0.88);
   }
 }
 
 .ghost-button {
-  min-height: 42px;
-  border: 1px solid #d4dcef;
-  border-radius: 999px;
-  padding: 0 0.95rem;
-  background: #fff;
-  color: #31415f;
+  min-height: 46px;
+  padding: 0 1rem;
+  border: 3px solid var(--primary);
+  border-radius: 18px;
+  background: #fffdf8;
+  color: var(--primary);
   font: inherit;
-  font-weight: 700;
+  font-weight: 900;
   cursor: pointer;
-  transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease;
+  box-shadow: 4px 6px 0 rgba(35, 52, 90, 0.88);
+  transition: transform 160ms ease, box-shadow 160ms ease;
 }
 
 .ghost-button:hover:not(:disabled) {
-  transform: translateY(-1px);
-  box-shadow: 0 8px 18px rgba(36, 50, 79, 0.1);
+  transform: translate(-1px, -1px);
+  box-shadow: 5px 7px 0 rgba(35, 52, 90, 0.92);
 }
 
 .ghost-button--accent {
-  background: #edf3ff;
-  border-color: #cdd9ff;
-  color: #2c56c9;
+  background: var(--accent-yellow);
 }
 
 .ghost-button--dark {
-  background: #1f3157;
-  border-color: #1f3157;
-  color: #fff;
+  background: var(--accent-mint);
 }
 
 .ghost-button:disabled {
@@ -159,17 +172,35 @@
 }
 
 .metric-card {
+  background: linear-gradient(180deg, #fffdf8 0%, #fff5d9 100%);
+
   span {
     display: block;
-    color: #68748d;
+    color: rgba(35, 52, 90, 0.72);
   }
 
   strong {
     display: block;
     margin-top: 0.45rem;
-    font-size: 2rem;
-    letter-spacing: -0.05em;
+    font-size: clamp(1.8rem, 2.8vw, 2.35rem);
+    letter-spacing: -0.06em;
   }
+}
+
+.metric-card--total {
+  background: linear-gradient(180deg, #fff7d2 0%, #fffdf8 100%);
+}
+
+.metric-card--available {
+  background: linear-gradient(180deg, #def6e6 0%, #fffdf8 100%);
+}
+
+.metric-card--active {
+  background: linear-gradient(180deg, #ffecc4 0%, #fffdf8 100%);
+}
+
+.metric-card--length {
+  background: linear-gradient(180deg, #eef0fb 0%, #fffdf8 100%);
 }
 
 .report-panels {
@@ -181,6 +212,7 @@
 .report-card {
   display: grid;
   gap: 1rem;
+  align-content: start;
 
   header {
     display: flex;
@@ -202,49 +234,56 @@
 
 .eyebrow {
   margin: 0;
-  color: #4d77ef;
+  color: rgba(35, 52, 90, 0.72);
   text-transform: uppercase;
   letter-spacing: 0.14em;
   font-size: 0.72rem;
-  font-weight: 800;
+  font-weight: 900;
 }
 
 h3 {
   margin: 0.2rem 0 0;
-  font-size: 1.45rem;
-  letter-spacing: -0.04em;
+  font-size: clamp(1.35rem, 2vw, 1.7rem);
+  letter-spacing: -0.05em;
 }
 
 .pill {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.45rem 0.8rem;
+  padding: 0.48rem 0.85rem;
+  border: 3px solid var(--primary);
   border-radius: 999px;
-  background: #eef7ea;
-  color: #35733a;
-  font-size: 0.84rem;
-  font-weight: 800;
+  background: #dff4dd;
+  color: #2a6f3e;
+  font-size: 0.8rem;
+  font-weight: 900;
+  box-shadow: 2px 3px 0 rgba(35, 52, 90, 0.78);
 }
 
 .pill--blue {
-  background: #edf3ff;
-  color: #3765d9;
+  background: #dbe8ff;
+  color: #284e9d;
 }
 
 .pill--warm {
-  background: #fff3de;
-  color: #bf7a12;
+  background: #ffe9b5;
+  color: #a76100;
 }
 
 .pill--slate {
-  background: #eef1f8;
-  color: #556784;
+  background: #eef0f8;
+  color: #4d5b77;
 }
 
 .chart-frame {
   position: relative;
   min-height: 320px;
+  padding: 0.65rem;
+  border: 3px solid rgba(35, 52, 90, 0.14);
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.68);
+  box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.45);
 }
 
 .chart-frame--compact {
@@ -257,9 +296,11 @@ h3 {
   gap: 0.75rem;
 
   div {
-    padding: 0.9rem;
+    padding: 0.95rem;
+    border: 3px solid rgba(35, 52, 90, 0.16);
     border-radius: 18px;
-    background: #f5f7fd;
+    background: #fff;
+    box-shadow: 3px 4px 0 rgba(35, 52, 90, 0.18);
   }
 
   strong,
@@ -274,7 +315,7 @@ h3 {
 
   span {
     margin-top: 0.25rem;
-    color: #66718c;
+    color: rgba(35, 52, 90, 0.72);
     font-size: 0.9rem;
   }
 }
@@ -289,7 +330,7 @@ h3 {
   p {
     max-width: 42rem;
     margin: 0.6rem auto 0;
-    color: #66718c;
+    color: rgba(35, 52, 90, 0.72);
   }
 }
 
@@ -303,8 +344,10 @@ h3 {
 .insight,
 .summary-row {
   padding: 1rem;
+  border: 3px solid rgba(35, 52, 90, 0.16);
   border-radius: 18px;
-  background: #f5f7fd;
+  background: #fff;
+  box-shadow: 3px 4px 0 rgba(35, 52, 90, 0.18);
 }
 
 .insight {
@@ -314,13 +357,13 @@ h3 {
   }
 
   span {
-    color: #66718c;
+    color: rgba(35, 52, 90, 0.72);
     font-size: 0.9rem;
   }
 
   strong {
-    margin-top: 0.35rem;
-    font-size: 1.2rem;
+    margin-top: 0.3rem;
+    font-size: 1.28rem;
     letter-spacing: -0.04em;
   }
 }
@@ -333,114 +376,158 @@ h3 {
 
 .summary-row {
   display: flex;
-  align-items: center;
   justify-content: space-between;
+  align-items: center;
   gap: 1rem;
 
-  strong,
   span {
-    display: block;
+    color: rgba(35, 52, 90, 0.76);
   }
 
-  span {
-    margin-top: 0.2rem;
-    color: #66718c;
-    font-size: 0.9rem;
+  strong {
+    font-size: 1.1rem;
   }
 
   em {
-    color: #3765d9;
     font-style: normal;
-    font-weight: 800;
+    font-weight: 900;
+    color: var(--primary);
   }
 }
 
 .empty {
   margin: 0;
-  color: #66718c;
+  color: rgba(35, 52, 90, 0.72);
 }
 
 .preview-overlay {
   position: fixed;
   inset: 0;
-  z-index: 60;
+  z-index: 30;
   display: grid;
   place-items: center;
-  padding: 1.5rem;
-  background: rgba(15, 23, 42, 0.5);
-  backdrop-filter: blur(5px);
+  padding: 1.25rem;
+  background: rgba(35, 52, 90, 0.28);
+  backdrop-filter: blur(6px);
 }
 
 .preview-panel {
-  inline-size: min(1100px, 100%);
-  block-size: min(88vh, 900px);
+  width: min(1100px, 100%);
+  max-height: min(90vh, 920px);
   display: grid;
-  grid-template-rows: auto 1fr;
   gap: 1rem;
   padding: 1.2rem;
+  border: 3px solid var(--primary);
   border-radius: 28px;
-  background: #fff;
-  box-shadow: 0 28px 60px rgba(15, 23, 42, 0.24);
+  background: var(--panel);
+  box-shadow: 8px 10px 0 rgba(35, 52, 90, 0.94);
 }
 
 .preview-frame {
-  overflow: hidden;
-  border: 1px solid #dbe3f3;
+  min-height: 60vh;
+  border: 3px solid var(--primary);
   border-radius: 22px;
-  background: #eef2fb;
+  overflow: hidden;
+  background: #fff;
+  box-shadow: 4px 6px 0 rgba(35, 52, 90, 0.2);
+}
 
-  iframe {
-    inline-size: 100%;
-    block-size: 100%;
-    min-block-size: 65vh;
-    border: 0;
-    background: #fff;
-  }
+.preview-frame iframe {
+  width: 100%;
+  height: 100%;
+  min-height: 60vh;
+  border: 0;
 }
 
 .preview-fallback {
   display: flex;
-  align-items: center;
   justify-content: space-between;
+  align-items: center;
   gap: 1rem;
-  color: #66718c;
-  font-size: 0.92rem;
-
-  a {
-    color: #2c56c9;
-    font-weight: 700;
-    text-decoration: none;
-  }
+  padding: 0.95rem 1rem;
+  border: 3px dashed rgba(35, 52, 90, 0.18);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.7);
+  color: rgba(35, 52, 90, 0.72);
 }
 
-@media (max-width: 1100px) {
-  .filters-grid,
-  .export-checks,
+.preview-fallback a {
+  color: var(--primary);
+  font-weight: 900;
+}
+
+@media (max-width: 1180px) {
   .metrics-grid,
-  .report-panels,
+  .filters-grid,
   .insights-grid {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .export-checks {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
-@media (max-width: 760px) {
-  .filters-header,
-  .filters-actions,
-  .export-config__header,
-  .export-config__actions,
-  .preview-panel__header,
-  .preview-panel__actions,
-  .report-card header,
-  .summary-row {
+@media (max-width: 900px) {
+  .report-panels {
     grid-template-columns: 1fr;
+  }
+
+  .filters-header,
+  .export-config__header,
+  .preview-panel__header,
+  .preview-panel__actions {
     display: grid;
   }
 
   .preview-fallback {
     display: grid;
   }
+}
 
-  .chart-legend {
+@media (max-width: 720px) {
+  .metrics-grid,
+  .filters-grid,
+  .insights-grid,
+  .chart-legend,
+  .export-checks {
     grid-template-columns: 1fr;
+  }
+
+  .filters-actions,
+  .export-config__actions,
+  .preview-panel__actions {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .filters-actions > *,
+  .export-config__actions > *,
+  .preview-panel__actions > * {
+    width: 100%;
+  }
+
+  .preview-panel {
+    padding: 1rem;
+  }
+
+  .preview-overlay {
+    padding: 0.75rem;
+  }
+}
+
+@media (max-width: 560px) {
+  .filters-card,
+  .metric-card,
+  .report-card,
+  .empty-report-state,
+  .insights-card,
+  .report-summary-card {
+    padding: 1rem;
+  }
+
+  .chart-frame,
+  .chart-frame--compact {
+    min-height: 240px;
   }
 }

--- a/src/app/pages/settings/settings-page.component.scss
+++ b/src/app/pages/settings/settings-page.component.scss
@@ -5,10 +5,23 @@
 }
 
 .settings-card {
-  padding: 1.1rem;
-  border-radius: 22px;
-  background: rgba(255, 255, 255, 0.84);
-  box-shadow: 0 16px 34px rgba(36, 50, 79, 0.09);
+  padding: 1.2rem;
+  border: 3px solid var(--primary);
+  border-radius: 28px;
+  background: var(--panel);
+  box-shadow: var(--shadow-lg);
+}
+
+.settings-card:nth-child(1) {
+  background:
+    radial-gradient(circle at top right, rgba(246, 215, 104, 0.18), transparent 28%),
+    var(--panel);
+}
+
+.settings-card:nth-child(2) {
+  background:
+    radial-gradient(circle at top right, rgba(142, 223, 192, 0.16), transparent 28%),
+    var(--panel);
 }
 
 .span-two {
@@ -17,17 +30,17 @@
 
 .eyebrow {
   margin: 0;
-  color: #4d77ef;
+  color: rgba(35, 52, 90, 0.72);
   text-transform: uppercase;
   letter-spacing: 0.14em;
   font-size: 0.72rem;
-  font-weight: 800;
+  font-weight: 900;
 }
 
 h3 {
   margin: 0.2rem 0 1rem;
-  font-size: 1.45rem;
-  letter-spacing: -0.04em;
+  font-size: clamp(1.35rem, 2vw, 1.7rem);
+  letter-spacing: -0.05em;
 }
 
 .catalog-header {
@@ -40,7 +53,7 @@ h3 {
 
 .catalog-intro {
   margin: 0.55rem 0 0;
-  color: #63708b;
+  color: rgba(35, 52, 90, 0.72);
 }
 
 label {
@@ -48,9 +61,9 @@ label {
   gap: 0.45rem;
 
   span {
-    color: #556178;
+    color: rgba(35, 52, 90, 0.78);
     font-size: 0.82rem;
-    font-weight: 800;
+    font-weight: 900;
     text-transform: uppercase;
     letter-spacing: 0.08em;
   }
@@ -59,13 +72,14 @@ label {
 input,
 textarea {
   width: 100%;
-  min-height: 3rem;
-  padding: 0.8rem 1rem;
-  border-radius: 14px;
-  border: 1px solid rgba(92, 106, 144, 0.14);
-  background: rgba(248, 250, 255, 0.96);
-  color: #22304a;
+  min-height: 3.1rem;
+  padding: 0.82rem 1rem;
+  border: 3px solid rgba(35, 52, 90, 0.2);
+  border-radius: 18px;
+  background: #fffdf8;
+  color: var(--primary);
   font: inherit;
+  box-shadow: 3px 4px 0 rgba(35, 52, 90, 0.82);
 }
 
 textarea {
@@ -79,11 +93,12 @@ textarea {
   justify-content: space-between;
   gap: 1rem;
   width: 100%;
-  padding: 0.95rem 1rem;
-  margin-bottom: 0.75rem;
-  border: 1px solid rgba(86, 101, 138, 0.12);
-  border-radius: 18px;
-  background: #fbfcff;
+  padding: 1rem 1.05rem;
+  margin-bottom: 0.8rem;
+  border: 3px solid rgba(35, 52, 90, 0.18);
+  border-radius: 22px;
+  background: #fffdf8;
+  box-shadow: 3px 4px 0 rgba(35, 52, 90, 0.18);
   text-align: left;
 
   strong,
@@ -92,48 +107,53 @@ textarea {
   }
 
   span {
-    color: #69748d;
+    color: rgba(35, 52, 90, 0.7);
     margin-top: 0.25rem;
   }
 }
 
 .toggle {
   position: relative;
-  width: 52px;
-  height: 30px;
+  width: 56px;
+  height: 32px;
+  border: 3px solid var(--primary);
   border-radius: 999px;
-  background: #dfe5f3;
+  background: #e5e7f0;
+  box-shadow: 2px 3px 0 rgba(35, 52, 90, 0.5);
   transition: background 0.2s ease;
 
   &::after {
     content: '';
     position: absolute;
-    top: 4px;
-    left: 4px;
-    width: 22px;
-    height: 22px;
+    top: 2px;
+    left: 3px;
+    width: 20px;
+    height: 20px;
     border-radius: 999px;
     background: #fff;
+    border: 2px solid var(--primary);
     transition: transform 0.2s ease;
   }
 
   &.active {
-    background: #4677f6;
+    background: var(--accent-mint);
   }
 
   &.active::after {
-    transform: translateX(22px);
+    transform: translateX(24px);
   }
 }
 
 .info-box {
   padding: 1rem;
-  border-radius: 18px;
-  background: linear-gradient(135deg, rgba(71, 119, 246, 0.08), rgba(255, 190, 90, 0.08));
+  border: 3px solid rgba(35, 52, 90, 0.16);
+  border-radius: 22px;
+  background: linear-gradient(135deg, rgba(246, 215, 104, 0.24), rgba(142, 223, 192, 0.18));
+  box-shadow: 3px 4px 0 rgba(35, 52, 90, 0.18);
 
   p {
     margin: 0.3rem 0 0;
-    color: #67738c;
+    color: rgba(35, 52, 90, 0.72);
     line-height: 1.55;
   }
 }
@@ -145,16 +165,19 @@ textarea {
 }
 
 .location-form,
-.locations-panel {
+.locations-panel,
+.technicians-card {
   padding: 1rem;
-  border-radius: 20px;
-  background: #fbfcff;
-  border: 1px solid rgba(86, 101, 138, 0.12);
+  border: 3px solid rgba(35, 52, 90, 0.16);
+  border-radius: 22px;
+  background: #fffdf8;
+  box-shadow: 3px 4px 0 rgba(35, 52, 90, 0.18);
 }
 
 .location-form {
   display: grid;
   gap: 0.9rem;
+  align-content: start;
 }
 
 .panel-header {
@@ -163,9 +186,11 @@ textarea {
   justify-content: space-between;
   gap: 1rem;
   margin-bottom: 0.9rem;
+  padding-bottom: 0.9rem;
+  border-bottom: 2px dashed rgba(35, 52, 90, 0.14);
 
   span {
-    color: #68758f;
+    color: rgba(35, 52, 90, 0.7);
   }
 }
 
@@ -180,30 +205,24 @@ textarea {
   display: grid;
   gap: 0.35rem;
   padding: 1rem;
-  border-radius: 20px;
-  background: #fbfcff;
-  border: 1px solid rgba(86, 101, 138, 0.12);
+  border: 3px solid rgba(35, 52, 90, 0.16);
+  border-radius: 22px;
+  background: #fff;
+  box-shadow: 3px 4px 0 rgba(35, 52, 90, 0.18);
 
   strong {
-    font-size: 2rem;
-    color: #1f3156;
+    font-size: clamp(1.8rem, 2.8vw, 2.3rem);
+    color: var(--primary);
   }
 }
 
 .summary-card--accent {
-  background: linear-gradient(135deg, rgba(71, 119, 246, 0.12), rgba(53, 162, 141, 0.14));
+  background: linear-gradient(135deg, rgba(246, 215, 104, 0.28), rgba(142, 223, 192, 0.22));
 }
 
 .summary-label {
-  color: #60708d;
-  font-weight: 800;
-}
-
-.technicians-card {
-  padding: 1rem;
-  border-radius: 20px;
-  background: #fbfcff;
-  border: 1px solid rgba(86, 101, 138, 0.12);
+  color: rgba(35, 52, 90, 0.76);
+  font-weight: 900;
 }
 
 .table-wrap {
@@ -213,10 +232,11 @@ textarea {
 
 .tech-table {
   min-width: 920px;
-  border: 1px solid rgba(84, 101, 144, 0.12);
-  border-radius: 18px;
+  border: 3px solid var(--primary);
+  border-radius: 22px;
   overflow: hidden;
-  background: #fff;
+  background: #fffdf8;
+  box-shadow: 4px 6px 0 rgba(35, 52, 90, 0.84);
 }
 
 .tech-table__head,
@@ -226,27 +246,33 @@ textarea {
 }
 
 .tech-table__head {
-  background: linear-gradient(180deg, #14356f 0%, #0d2a5a 100%);
-  color: #fff;
+  background: var(--accent-mint);
+  color: var(--primary);
   font-size: 0.8rem;
-  font-weight: 800;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
 }
 
 .tech-table__head span,
 .tech-table__row span {
   padding: 0.95rem 0.85rem;
-  border-right: 1px solid rgba(84, 101, 144, 0.08);
+  border-right: 2px solid rgba(35, 52, 90, 0.08);
 }
 
 .tech-table__row {
   align-items: center;
-  border-top: 1px solid rgba(84, 101, 144, 0.1);
-  color: #30405d;
+  border-top: 2px solid rgba(35, 52, 90, 0.1);
+  color: rgba(35, 52, 90, 0.9);
   background: #fff;
 }
 
+.tech-table__row:nth-child(even) {
+  background: rgba(246, 215, 104, 0.1);
+}
+
 .primary-cell {
-  font-weight: 800;
+  font-weight: 900;
 }
 
 .state-pill {
@@ -256,15 +282,17 @@ textarea {
   min-width: 84px;
   min-height: 2.2rem;
   padding: 0 0.85rem;
+  border: 3px solid var(--primary);
   border-radius: 999px;
-  background: #eef7ea;
-  color: #2f7f37;
-  font-weight: 800;
+  background: #dff4dd;
+  color: #2a6f3e;
+  font-weight: 900;
+  box-shadow: 2px 3px 0 rgba(35, 52, 90, 0.78);
 }
 
 .state-pill--inactive {
-  background: #fff4df;
-  color: #b46a10;
+  background: #ffe9b5;
+  color: #a76100;
 }
 
 .actions-cell {
@@ -284,14 +312,20 @@ textarea {
   justify-content: space-between;
   gap: 1rem;
   padding: 0.95rem 1rem;
-  border-radius: 16px;
+  border: 3px solid rgba(35, 52, 90, 0.14);
+  border-radius: 18px;
   background: #fff;
-  border: 1px solid rgba(86, 101, 138, 0.1);
+  box-shadow: 3px 4px 0 rgba(35, 52, 90, 0.14);
 
   p {
     margin: 0.35rem 0 0;
-    color: #69748d;
+    color: rgba(35, 52, 90, 0.72);
     line-height: 1.45;
+  }
+
+  strong {
+    font-size: 1rem;
+    font-weight: 900;
   }
 }
 
@@ -300,17 +334,27 @@ textarea {
   display: flex;
   gap: 0.65rem;
   justify-content: flex-end;
+  flex-wrap: wrap;
 }
 
 .primary-button,
 .secondary-button,
 .danger-button {
-  min-height: 2.8rem;
+  min-height: 2.9rem;
   padding: 0 1rem;
-  border-radius: 12px;
-  border: none;
+  border: 3px solid var(--primary);
+  border-radius: 16px;
   font: inherit;
-  font-weight: 800;
+  font-weight: 900;
+  box-shadow: 4px 6px 0 rgba(35, 52, 90, 0.88);
+  transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease;
+}
+
+.primary-button:hover,
+.secondary-button:hover,
+.danger-button:hover {
+  transform: translate(-1px, -1px);
+  box-shadow: 5px 7px 0 rgba(35, 52, 90, 0.92);
 }
 
 .small-button {
@@ -319,69 +363,114 @@ textarea {
 }
 
 .primary-button {
-  background: linear-gradient(135deg, #1745a7, #0f3690);
-  color: #fff;
+  background: var(--accent-yellow);
+  color: var(--primary);
 }
 
 .secondary-button {
-  background: #eef2ff;
-  color: #224aa5;
+  background: #fffdf8;
+  color: var(--primary);
 }
 
 .danger-button {
-  background: #fff1f1;
-  color: #ba3131;
+  background: #ffe3de;
+  color: #a93d31;
 }
 
 .empty-box,
 .form-alert,
 .field-error {
-  color: #66718c;
+  color: rgba(35, 52, 90, 0.72);
 }
 
-.empty-box {
-  padding: 1rem;
-  border-radius: 16px;
-  background: #f6f8fe;
-  text-align: center;
+.empty-box,
+.form-alert {
+  padding: 0.95rem 1rem;
+  border: 3px dashed rgba(35, 52, 90, 0.18);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.7);
 }
 
-.form-alert,
 .field-error {
-  font-size: 0.82rem;
-}
-
-.form-alert,
-.field-error {
-  color: #b43333;
+  color: #b34235;
+  font-weight: 800;
 }
 
 .notes {
-  margin: 0;
-  padding-left: 1.2rem;
-  color: #58647f;
-
-  li + li {
-    margin-top: 0.55rem;
-  }
+  display: grid;
+  gap: 0.8rem;
+  margin: 1rem 0 0;
+  padding: 0;
+  list-style: none;
 }
 
-@media (max-width: 900px) {
+.notes li {
+  position: relative;
+  padding: 0.95rem 1rem 0.95rem 3.2rem;
+  border: 3px solid rgba(35, 52, 90, 0.14);
+  border-radius: 20px;
+  background: linear-gradient(135deg, rgba(246, 215, 104, 0.2), rgba(255, 255, 255, 0.8));
+  box-shadow: 3px 4px 0 rgba(35, 52, 90, 0.14);
+  line-height: 1.55;
+}
+
+.notes li::before {
+  content: '•';
+  position: absolute;
+  left: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 2px solid var(--primary);
+  border-radius: 999px;
+  background: #fffdf8;
+  color: var(--primary);
+  font-weight: 900;
+}
+
+@media (max-width: 1080px) {
   .settings-grid {
     grid-template-columns: 1fr;
   }
 
   .span-two {
-    grid-column: span 1;
+    grid-column: auto;
   }
 
-  .catalog-header,
-  .summary-grid,
-  .locations-layout,
-  .location-item,
-  .location-actions,
-  .form-actions {
+  .locations-layout {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .catalog-header,
+  .panel-header,
+  .summary-grid {
     display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .location-item {
+    display: grid;
+  }
+
+  .location-actions,
+  .form-actions,
+  .actions-cell {
+    width: 100%;
+  }
+
+  .location-actions > *,
+  .form-actions > *,
+  .actions-cell > * {
+    width: 100%;
+  }
+
+  .toggle-row {
+    align-items: start;
   }
 }

--- a/src/app/pages/technicians/technicians-page.component.scss
+++ b/src/app/pages/technicians/technicians-page.component.scss
@@ -1,15 +1,16 @@
 .technicians-page {
   display: grid;
-  gap: 1rem;
+  gap: 1.2rem;
 }
 
 .page-header,
 .summary-card,
 .table-card {
-  padding: 1.2rem;
-  border-radius: 24px;
-  background: rgba(255, 255, 255, 0.84);
-  box-shadow: 0 16px 34px rgba(36, 50, 79, 0.09);
+  padding: 1.25rem;
+  border: 3px solid var(--primary);
+  border-radius: 28px;
+  background: var(--panel);
+  box-shadow: var(--shadow-lg);
 }
 
 .page-header,
@@ -20,29 +21,35 @@
   gap: 1rem;
 }
 
+.page-header {
+  background:
+    radial-gradient(circle at top right, rgba(142, 223, 192, 0.16), transparent 30%),
+    var(--panel);
+}
+
 .eyebrow {
   margin: 0;
-  color: #4d77ef;
+  color: rgba(35, 52, 90, 0.72);
   text-transform: uppercase;
   letter-spacing: 0.14em;
   font-size: 0.72rem;
-  font-weight: 800;
+  font-weight: 900;
 }
 
 h2,
 h3 {
   margin: 0.25rem 0 0;
-  letter-spacing: -0.04em;
+  letter-spacing: -0.05em;
 }
 
 h2 {
-  font-size: 2rem;
+  font-size: clamp(1.9rem, 3vw, 2.45rem);
 }
 
 .intro,
 .table-toolbar p {
   margin: 0.65rem 0 0;
-  color: #63708b;
+  color: rgba(35, 52, 90, 0.72);
 }
 
 .summary-grid {
@@ -54,20 +61,21 @@ h2 {
 .summary-card {
   display: grid;
   gap: 0.35rem;
+  background: linear-gradient(180deg, #fffdf8 0%, #fff6e0 100%);
 
   strong {
-    font-size: 2rem;
-    color: #1f3156;
+    font-size: clamp(1.8rem, 2.8vw, 2.3rem);
+    color: var(--primary);
   }
 }
 
 .summary-card--accent {
-  background: linear-gradient(135deg, rgba(71, 119, 246, 0.12), rgba(53, 162, 141, 0.14));
+  background: linear-gradient(135deg, rgba(246, 215, 104, 0.28), rgba(142, 223, 192, 0.22));
 }
 
 .summary-label {
-  color: #60708d;
-  font-weight: 800;
+  color: rgba(35, 52, 90, 0.76);
+  font-weight: 900;
 }
 
 .primary,
@@ -75,25 +83,34 @@ h2 {
 .danger {
   min-height: 3rem;
   padding: 0 1.1rem;
-  border-radius: 14px;
-  font-weight: 800;
+  border-radius: 16px;
+  font-weight: 900;
   font: inherit;
-  border: none;
+  border: 3px solid var(--primary);
+  box-shadow: 4px 6px 0 rgba(35, 52, 90, 0.88);
+  transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease;
 }
 
 .primary {
-  background: linear-gradient(135deg, #1745a7, #0f3690);
-  color: #fff;
+  background: var(--accent-yellow);
+  color: var(--primary);
 }
 
 .secondary {
-  background: #edf2ff;
-  color: #224aa5;
+  background: #fffdf8;
+  color: var(--primary);
 }
 
 .danger {
-  background: #fff1f1;
-  color: #ba3131;
+  background: #ffe3de;
+  color: #a93d31;
+}
+
+.primary:hover,
+.secondary:hover,
+.danger:hover {
+  transform: translate(-1px, -1px);
+  box-shadow: 5px 7px 0 rgba(35, 52, 90, 0.92);
 }
 
 .small {
@@ -108,10 +125,11 @@ h2 {
 
 .tech-table {
   min-width: 920px;
-  border: 1px solid rgba(84, 101, 144, 0.12);
-  border-radius: 18px;
+  border: 3px solid var(--primary);
+  border-radius: 22px;
   overflow: hidden;
-  background: #fbfcff;
+  background: #fffdf8;
+  box-shadow: 4px 6px 0 rgba(35, 52, 90, 0.84);
 }
 
 .tech-table__head,
@@ -121,27 +139,37 @@ h2 {
 }
 
 .tech-table__head {
-  background: linear-gradient(180deg, #14356f 0%, #0d2a5a 100%);
-  color: #fff;
+  background: var(--accent-mint);
+  color: var(--primary);
   font-size: 0.8rem;
-  font-weight: 800;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
 }
 
 .tech-table__head span,
 .tech-table__row span {
   padding: 0.95rem 0.85rem;
-  border-right: 1px solid rgba(84, 101, 144, 0.08);
+  border-right: 2px solid rgba(35, 52, 90, 0.08);
 }
 
 .tech-table__row {
   align-items: center;
-  border-top: 1px solid rgba(84, 101, 144, 0.1);
-  color: #30405d;
+  border-top: 2px solid rgba(35, 52, 90, 0.1);
+  color: rgba(35, 52, 90, 0.9);
   background: #fff;
 }
 
+.tech-table__row:nth-child(even) {
+  background: rgba(246, 215, 104, 0.1);
+}
+
+.tech-table__row:hover {
+  background: rgba(142, 223, 192, 0.12);
+}
+
 .primary-cell {
-  font-weight: 800;
+  font-weight: 900;
 }
 
 .state-pill {
@@ -151,29 +179,33 @@ h2 {
   min-width: 84px;
   min-height: 2.2rem;
   padding: 0 0.85rem;
+  border: 3px solid var(--primary);
   border-radius: 999px;
-  background: #eef7ea;
-  color: #2f7f37;
-  font-weight: 800;
+  background: #dff4dd;
+  color: #2a6f3e;
+  font-weight: 900;
+  box-shadow: 2px 3px 0 rgba(35, 52, 90, 0.78);
 }
 
 .state-pill--inactive {
-  background: #fff4df;
-  color: #b46a10;
+  background: #ffe9b5;
+  color: #a76100;
 }
 
 .actions-cell {
   display: flex;
   gap: 0.65rem;
   align-items: center;
+  flex-wrap: wrap;
 }
 
 .empty-state {
   margin-top: 1rem;
   padding: 1.2rem;
-  border-radius: 18px;
-  background: #f6f8fe;
-  color: #66718c;
+  border: 3px dashed rgba(35, 52, 90, 0.2);
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.75);
+  color: rgba(35, 52, 90, 0.72);
   text-align: center;
 }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -37,26 +37,31 @@ body {
 }
 :root {
   color-scheme: light;
-  --bg: #eef1f8;
-  --panel: #ffffff;
-  --panel-soft: rgba(255, 255, 255, 0.72);
-  --sidebar-top: #44506e;
-  --sidebar-bottom: #2e3953;
-  --text: #243047;
-  --muted: #6e7891;
-  --line: rgba(64, 79, 119, 0.12);
-  --primary: #4677f6;
-  --primary-strong: #2f5fe0;
-  --success: #4f9b43;
-  --warning: #e18a11;
-  --danger: #d95b57;
-  --info: #6f7d9b;
-  --shadow-lg: 0 24px 60px rgba(37, 55, 102, 0.12);
-  --shadow-md: 0 12px 28px rgba(38, 54, 95, 0.1);
-  --radius-xl: 28px;
+  --bg: #f6f1e7;
+  --panel: #fffdf8;
+  --panel-soft: rgba(255, 253, 248, 0.92);
+  --sidebar-top: #fffdf8;
+  --sidebar-bottom: #fff8ef;
+  --text: #23345a;
+  --muted: #5f6e90;
+  --line: rgba(35, 52, 90, 0.18);
+  --primary: #23345a;
+  --primary-strong: #182748;
+  --success: #4ea07d;
+  --warning: #e1b848;
+  --danger: #d7685f;
+  --info: #6b7b9f;
+  --accent-yellow: #f6d768;
+  --accent-mint: #8edfc0;
+  --accent-cream: #fff7d7;
+  --accent-sky: #dbe8ff;
+  --shadow-lg: 8px 10px 0 rgba(35, 52, 90, 0.94);
+  --shadow-md: 6px 8px 0 rgba(35, 52, 90, 0.92);
+  --shadow-sm: 4px 5px 0 rgba(35, 52, 90, 0.86);
+  --radius-xl: 26px;
   --radius-lg: 20px;
-  --radius-md: 14px;
-  --radius-sm: 10px;
+  --radius-md: 16px;
+  --radius-sm: 12px;
 }
 
 * {
@@ -67,15 +72,17 @@ html,
 body {
   margin: 0;
   min-height: 100%;
-  font-family: 'Manrope', sans-serif;
+  font-family: "Avenir Next", "Trebuchet MS", "Segoe UI", sans-serif;
   background:
-    radial-gradient(circle at top left, rgba(86, 120, 246, 0.18), transparent 28%),
-    linear-gradient(180deg, #f6f7fb 0%, #eef1f8 100%);
+    radial-gradient(circle at top left, rgba(246, 215, 104, 0.26), transparent 20%),
+    radial-gradient(circle at bottom right, rgba(142, 223, 192, 0.22), transparent 18%),
+    linear-gradient(180deg, #f8f4eb 0%, #f4efe5 100%);
   color: var(--text);
 }
 
 body {
   min-height: 100vh;
+  line-height: 1.45;
 }
 
 button,
@@ -83,9 +90,46 @@ input,
 select,
 textarea {
   font: inherit;
+  -webkit-tap-highlight-color: transparent;
 }
 
 button {
   cursor: pointer;
 }
 
+button:disabled {
+  cursor: default;
+}
+
+::selection {
+  background: rgba(246, 215, 104, 0.62);
+  color: var(--primary);
+}
+
+h1,
+h2,
+h3,
+h4,
+p,
+button,
+label,
+span,
+strong,
+dt,
+dd {
+  overflow-wrap: anywhere;
+}
+
+h1,
+h2,
+h3,
+h4,
+button {
+  text-wrap: balance;
+}
+
+p,
+li,
+dd {
+  text-wrap: pretty;
+}


### PR DESCRIPTION
He aplicado el rediseño base para que el frontend se acerque mucho más a tus referencias: fondo blanco roto, bordes navy marcados, sombras duras desplazadas, bloques crema/amarillo/menta y una tipografía más redondeada y protagonista, cuidando además que los textos se adapten sin salirse.

Los cambios principales están en:

styles.scss
app-shell.component.scss
dashboard-page.component.scss
tool-card.component.scss
inventory-page.component.scss
tool-form-modal.component.scss
confirm-dialog.component.scss
toast-stack.component.scss
También ajusté la estructura visual del Tablero y de las tarjetas para que cada columna tenga más personalidad pastel y para que los botones, badges y paneles sigan el mismo lenguaje gráfico.